### PR TITLE
Feature delivery policy packet patching

### DIFF
--- a/nodejs-server/src/modules/clients/Client.js
+++ b/nodejs-server/src/modules/clients/Client.js
@@ -24,11 +24,11 @@ export default class Client {
     } else {
       // Check packet queue
       if (this.packetQueue.length > 0) {
-        // Check send rate timer
+        // Check packet send rate timer
         if (this.packetSendRateTimer >= this.packetSendRate) {
-          // Reset send rate timer
-          this.packetSendRateTimer = 0;
+          // Fetch network packet
           networkPacket = this.packetQueue.shift();
+          // Send rate timer is restarted after packet is successfully sent
         }
       }
     }

--- a/world-against-us/scripts/NetworkConnectionSampler/NetworkConnectionSampler.gml
+++ b/world-against-us/scripts/NetworkConnectionSampler/NetworkConnectionSampler.gml
@@ -74,24 +74,10 @@ function NetworkConnectionSampler() constructor
 			AckTimeoutFuncPinging
 		);
 		
-		var networkPacketBuilder = global.NetworkHandlerRef.network_packet_builder;
-		if (networkPacketBuilder.CreatePingPacket(global.NetworkHandlerRef.pre_alloc_network_buffer, networkPacket))
+		// PREPARE AND SEND PING NETWORK PACKET
+		if (!global.NetworkHandlerRef.PrepareAndSendNetworkPacket(networkPacket))
 		{
-			var sentNetworkPacketBytes = global.NetworkHandlerRef.SendPacketOverUDP();
-			if (sentNetworkPacketBytes > 0)
-			{
-				var consoleLog = string(
-					"Network packet ({0}) {1}kb sent >> Packet send interval 1000ms (Ping)",
-					networkPacket.header.message_type,
-					BytesToKilobits(sentNetworkPacketBytes)
-				);
-				global.ConsoleHandlerRef.AddConsoleLog(CONSOLE_LOG_TYPE.INFO, consoleLog);
-				
-				// UPDATE DATA OUT RATE
-				global.NetworkConnectionSamplerRef.data_out_rate += sentNetworkPacketBytes;
-			} else {
-				show_debug_message("Failed to send PING packet");
-			}
+			global.ConsoleHandlerRef.AddConsoleLog(CONSOLE_LOG_TYPE.WARNING, "Failed to send PING network packet");
 		}
 		
 		// START TIMEOUT TIMER


### PR DESCRIPTION
Fix network packet patching logic to utilize delivery policies on both server and client side.
Add function to prepare and send network packets on server side,
and remove duplicate network packet sending and patching code.
Simplify network packet send function names on both server and client side.
Fix in-flight packet track, ACK range, and send rate patching and clean-up on sent network packet on both server and client side.