### PR TITLE
Add networking inventory stack item on split

### DIFF
--- a/world-against-us/scripts/NetworkInventoryStackItem/NetworkInventoryStackItem.gml
+++ b/world-against-us/scripts/NetworkInventoryStackItem/NetworkInventoryStackItem.gml
@@ -1,0 +1,30 @@
+function NetworkInventoryStackItem(_inventory, _sourceQuantity, _sourceItem, _targetItem)
+{
+	if (global.MultiplayerMode)
+	{
+		if (IsInventoryContainer(_inventory.type))
+		{
+			// TODO: Simplify combine logic
+			var stackedSourceItem = _sourceItem.Clone();
+			// PATCH GRID INDEX
+			stackedSourceItem.grid_index = _targetItem.grid_index.Clone();
+			// PATCH STACK OPERATION QUANTITY
+			stackedSourceItem.quantity = _sourceQuantity - _sourceItem.quantity;
+			var containerInventoryActionInfo = new ContainerInventoryActionInfo(_inventory.inventory_id, undefined, undefined, undefined, undefined, stackedSourceItem);
+			var networkPacketHeader = new NetworkPacketHeader(MESSAGE_TYPE.CONTAINER_INVENTORY_STACK_ITEM);
+			var networkPacket = new NetworkPacket(
+				networkPacketHeader,
+				containerInventoryActionInfo.ToJSONStruct(),
+				PACKET_PRIORITY.DEFAULT,
+				AckTimeoutFuncResend
+			);
+			if (!global.NetworkHandlerRef.AddPacketToQueue(networkPacket))
+			{
+				show_debug_message("Failed to stack item to container inventory");
+			}
+			// DELETE TEMP STACKED SOURCE ITEM
+			stackedSourceItem.OnDestroy();
+			stackedSourceItem = undefined;
+		}
+	}
+}

--- a/world-against-us/scripts/NetworkInventoryStackItem/NetworkInventoryStackItem.yy
+++ b/world-against-us/scripts/NetworkInventoryStackItem/NetworkInventoryStackItem.yy
@@ -1,0 +1,11 @@
+{
+  "resourceType": "GMScript",
+  "resourceVersion": "1.0",
+  "name": "NetworkInventoryStackItem",
+  "isCompatibility": false,
+  "isDnD": false,
+  "parent": {
+    "name": "Inventory",
+    "path": "folders/Scripts/Game/Network/Inventory.yy",
+  },
+}

--- a/world-against-us/scripts/OnReleasedGUIDragItem/OnReleasedGUIDragItem.gml
+++ b/world-against-us/scripts/OnReleasedGUIDragItem/OnReleasedGUIDragItem.gml
@@ -41,33 +41,8 @@ function OnReleasedGUIDragItem(_inventory, _mouseHoverIndex)
 					if (CombineItems(dragItemData, targetItem))
 					{
 						// NETWORKING STACK ITEM
-						if (global.MultiplayerMode)
-						{
-							if (IsInventoryContainer(_inventory.type))
-							{
-								// TODO: Simplify combine logic
-								var stackedSourceItem = dragItemData.Clone();
-								// PATCH GRID INDEX
-								stackedSourceItem.grid_index = targetItem.grid_index.Clone();
-								// PATCH STACK OPERATION QUANTITY
-								stackedSourceItem.quantity = sourceQuantity - dragItemData.quantity;
-								var containerInventoryActionInfo = new ContainerInventoryActionInfo(_inventory.inventory_id, undefined, undefined, undefined, undefined, stackedSourceItem);
-								var networkPacketHeader = new NetworkPacketHeader(MESSAGE_TYPE.CONTAINER_INVENTORY_STACK_ITEM);
-								var networkPacket = new NetworkPacket(
-									networkPacketHeader,
-									containerInventoryActionInfo.ToJSONStruct(),
-									PACKET_PRIORITY.DEFAULT,
-									AckTimeoutFuncResend
-								);
-								if (!global.NetworkHandlerRef.AddPacketToQueue(networkPacket))
-								{
-									show_debug_message("Failed to stack item to container inventory");
-								}
-								// DELETE TEMP STACKED SOURCE ITEM
-								stackedSourceItem.OnDestroy();
-								stackedSourceItem = undefined;
-							}
-						}
+						NetworkInventoryStackItem(_inventory, sourceQuantity, dragItemData, targetItem);
+						
 						isDragItemDropped = true;
 					}
 				}

--- a/world-against-us/scripts/OnReleasedGUIDragItemSplit/OnReleasedGUIDragItemSplit.gml
+++ b/world-against-us/scripts/OnReleasedGUIDragItemSplit/OnReleasedGUIDragItemSplit.gml
@@ -26,7 +26,9 @@ function OnReleasedGUIDragItemSplit(_inventory, _mouseHoverIndex)
 					var targetItem = _inventory.GetItemByGridIndex(targetItemGridIndex);
 					if (!is_undefined(targetItem))
 					{
+						// TODO: Simplify combine logic
 						var itemCloneToCombine = dragItemData.Clone(splitQuantity);
+						var sourceQuantity = dragItemData.quantity;
 						if (CombineItems(itemCloneToCombine, targetItem))
 						{
 							isDragItemStackEmpty = true;
@@ -34,6 +36,10 @@ function OnReleasedGUIDragItemSplit(_inventory, _mouseHoverIndex)
 						
 						// CHECK IF DRAG ITEM STACK IS EMPTY
 						dragItemData.quantity -= (isDragItemStackEmpty) ? splitQuantity : (splitQuantity - itemCloneToCombine.quantity);
+						
+						// NETWORKING STACK ITEM
+						NetworkInventoryStackItem(_inventory, sourceQuantity, dragItemData, targetItem);
+						
 						isDragItemStackEmpty = (dragItemData.quantity <= 0);
 					}
 				}


### PR DESCRIPTION
Add generic networking function to stack items to inventory on split on client side.
Remove duplicate code from OnReleasedGUIDragItem and OnReleasedGUIDragItemSplit functions.