### PR TITLE
Bugfix autosave on last client disconnect

### DIFF
--- a/nodejs-server/src/modules/network/NetworkHandler.js
+++ b/nodejs-server/src/modules/network/NetworkHandler.js
@@ -666,6 +666,11 @@ export default class NetworkHandler {
             `Failed to disconnect a client with ID: ${clientId}`
           );
         }
+
+        // Autosave on last client disconnect
+        if (this.clientHandler.getClientCount() <= 0) {
+          this.worldStateHandler.autosave();
+        }
       }, 1000);
     } else {
       client = new Client(UNDEFINED_UUID, clientAddress, clientPort);
@@ -713,9 +718,6 @@ export default class NetworkHandler {
         );
       }
     }
-
-    // Autosave on last client disconnect
-    this.worldStateHandler.autosave();
 
     ConsoleHandler.Log(
       `Player '${client.playerTag}' disconnected from the server`


### PR DESCRIPTION
Fixed server-side autosave logic to save the world state on the last client disconnect, and not on every disconnect.