### PR TITLE
Add debug monitor graph network

### DIFF
--- a/world-against-us/objects/objDebugMonitor/Create_0.gml
+++ b/world-against-us/objects/objDebugMonitor/Create_0.gml
@@ -1,1 +1,2 @@
 debugMonitorGameHandler = new DebugMonitorGameHandler();
+debugMonitorNetworkHandler = new DebugMonitorNetworkHandler();

--- a/world-against-us/objects/objDebugMonitor/Step_0.gml
+++ b/world-against-us/objects/objDebugMonitor/Step_0.gml
@@ -8,7 +8,7 @@ if (keyboard_check_released(KEY_DEBUG_MONITOR))
 			CreateWindowDebugMonitorGame(GAME_WINDOW.DebugMonitor, -1, debugMonitorGameHandler)
 		],
 		GUI_CHAIN_RULE.OverwriteAll,
-		undefined, undefined
+		CallbackGUIStateInputDebugMonitor, undefined
 	);
 	global.GUIStateHandlerRef.RequestGUIState(guiState);
 }

--- a/world-against-us/objects/objglobals/Create_0.gml
+++ b/world-against-us/objects/objglobals/Create_0.gml
@@ -124,6 +124,7 @@ global.GUIStateHandlerRef = undefined;
 global.ObjMouse = noone;
 global.ConsoleHandlerRef = undefined;
 global.DebugMonitorGameHandlerRef = undefined;
+global.DebugMonitorNetworkHandlerRef = undefined;
 global.NotificationHandlerRef = undefined;
 global.ObjNetwork = noone;
 global.NetworkHandlerRef = undefined;

--- a/world-against-us/objects/objglobals/Other_10.gml
+++ b/world-against-us/objects/objglobals/Other_10.gml
@@ -8,6 +8,7 @@ global.ObjMouse = instance_exists(objMouse) ? instance_find(objMouse, 0) : noone
 global.NotificationHandlerRef = instance_exists(objNotification) ? instance_find(objNotification, 0).notificationHandler : undefined;
 global.ConsoleHandlerRef = instance_exists(objConsole) ? instance_find(objConsole, 0).consoleHandler : undefined;
 global.DebugMonitorGameHandlerRef = instance_exists(objDebugMonitor) ? instance_find(objDebugMonitor, 0).debugMonitorGameHandler : undefined;
+global.DebugMonitorNetworkHandlerRef = instance_exists(objDebugMonitor) ? instance_find(objDebugMonitor, 0).debugMonitorNetworkHandler : undefined;
 global.ObjNetwork = instance_exists(objNetwork) ? instance_find(objNetwork, 0) : noone;
 global.NetworkHandlerRef = instance_exists(objNetwork) ? instance_find(objNetwork, 0).networkHandler : undefined;
 global.NetworkRegionHandlerRef = (!is_undefined(global.NetworkHandlerRef)) ? global.NetworkHandlerRef.network_region_handler : undefined;

--- a/world-against-us/scripts/CallbackGUIStateInputDebugMonitor/CallbackGUIStateInputDebugMonitor.gml
+++ b/world-against-us/scripts/CallbackGUIStateInputDebugMonitor/CallbackGUIStateInputDebugMonitor.gml
@@ -1,0 +1,20 @@
+function CallbackGUIStateInputDebugMonitor()
+{
+	var currentGUIState = global.GUIStateHandlerRef.GetGUIState();
+	if (currentGUIState.index == GUI_STATE.DebugMonitor)
+	{
+		if (keyboard_check_released(ord("1")))
+		{
+			// OPEN GAME MONITORING
+			global.GUIStateHandlerRef.RequestGUIView(GUI_VIEW.DebugMonitorGame, [
+				CreateWindowDebugMonitorGame(GAME_WINDOW.DebugMonitor, -1, global.DebugMonitorGameHandlerRef)
+			], GUI_CHAIN_RULE.OverwriteAll);
+		} else if (keyboard_check_released(ord("2")))
+		{
+			// OPEN NETWORK MONITORING
+			global.GUIStateHandlerRef.RequestGUIView(GUI_VIEW.DebugMonitorNetwork, [
+				CreateWindowDebugMonitorNetwork(GAME_WINDOW.DebugMonitor, -1, global.DebugMonitorNetworkHandlerRef)
+			], GUI_CHAIN_RULE.OverwriteAll);
+		}
+	}
+}

--- a/world-against-us/scripts/CallbackGUIStateInputDebugMonitor/CallbackGUIStateInputDebugMonitor.yy
+++ b/world-against-us/scripts/CallbackGUIStateInputDebugMonitor/CallbackGUIStateInputDebugMonitor.yy
@@ -1,0 +1,11 @@
+{
+  "resourceType": "GMScript",
+  "resourceVersion": "1.0",
+  "name": "CallbackGUIStateInputDebugMonitor",
+  "isCompatibility": false,
+  "isDnD": false,
+  "parent": {
+    "name": "DebugMonitor",
+    "path": "folders/Scripts/Game/GUI/DebugMonitor.yy",
+  },
+}

--- a/world-against-us/scripts/CreateWindowDebugMonitorNetwork/CreateWindowDebugMonitorNetwork.gml
+++ b/world-against-us/scripts/CreateWindowDebugMonitorNetwork/CreateWindowDebugMonitorNetwork.gml
@@ -1,0 +1,120 @@
+function CreateWindowDebugMonitorNetwork(_gameWindowId, _zIndex, _debugNetworkHandlerRef)
+{
+	var windowSize = new Size(global.GUIW, global.GUIH);
+	var windowStyle = new GameWindowStyle(c_black, 1);
+	var monitorWindow = new GameWindow(
+		_gameWindowId,
+		new Vector2(0, 0),
+		windowSize, windowStyle, _zIndex
+	);
+	
+	var monitorElements = ds_list_create();
+	
+	var monitorTitlePosition = new Vector2(10, 10);
+	var monitorTitleElement = new WindowText(
+		"MonitorTitle",
+		monitorTitlePosition,
+		undefined, undefined,
+		"Debug Monitor - Network", font_default, fa_left, fa_top, c_white, 1
+	);
+	
+	var monitorGraphPosition = new Vector2(80, 150);
+	var monitorGraphSize = new Size(800, 300);
+	var pingSamplesClone = [];
+	array_copy(
+		pingSamplesClone, 0,
+		_debugNetworkHandlerRef.ping_samples, 0,
+		array_length(_debugNetworkHandlerRef.ping_samples)
+	);
+	var monitorPingGraphElement = new WindowDebugMonitorGraph(
+		"MonitorPingGraph",
+		monitorGraphPosition,
+		monitorGraphSize,
+		#1f1f1f,
+		pingSamplesClone,
+		"Ping sampling",
+		"Ping",
+		_debugNetworkHandlerRef.ping_sample_interval,
+		_debugNetworkHandlerRef.ping_samples_max_value,
+		"ms",
+		#2bbbf2,
+		undefined
+	);
+	
+	monitorGraphPosition = new Vector2(970, 150);
+	var packetDropSamplesClone = [];
+	array_copy(
+		packetDropSamplesClone, 0,
+		_debugNetworkHandlerRef.packet_loss_samples, 0,
+		array_length(_debugNetworkHandlerRef.packet_loss_samples)
+	);
+	var monitorPacketLossGraphElement = new WindowDebugMonitorGraph(
+		"MonitorPacketLossGraph",
+		monitorGraphPosition,
+		monitorGraphSize,
+		#1f1f1f,
+		packetDropSamplesClone,
+		"Over time packet loss count sampling",
+		"Total count",
+		undefined,
+		_debugNetworkHandlerRef.packet_loss_samples_max_value,
+		"count",
+		#2bbbf2,
+		#f2a035
+	);
+	
+	monitorGraphPosition = new Vector2(80, 570);
+	var dataOutSamplesClone = [];
+	array_copy(
+		dataOutSamplesClone, 0,
+		_debugNetworkHandlerRef.data_out_samples, 0,
+		array_length(_debugNetworkHandlerRef.data_out_samples)
+	);
+	var monitorDataOutGraphElement = new WindowDebugMonitorGraph(
+		"MonitorDataOutGraph",
+		monitorGraphPosition,
+		monitorGraphSize,
+		#1f1f1f,
+		dataOutSamplesClone,
+		"Sent data sampling",
+		"Data rate (out)",
+		_debugNetworkHandlerRef.data_rate_sample_interval,
+		_debugNetworkHandlerRef.data_out_samples_max_value,
+		"kb/s",
+		#2bbbf2,
+		undefined
+	);
+	
+	monitorGraphPosition = new Vector2(970, 570);
+	var dataInSamplesClone = [];
+	array_copy(
+		dataInSamplesClone, 0,
+		_debugNetworkHandlerRef.data_in_samples, 0,
+		array_length(_debugNetworkHandlerRef.data_in_samples)
+	);
+	var monitorDataInGraphElement = new WindowDebugMonitorGraph(
+		"MonitorDataInGraph",
+		monitorGraphPosition,
+		monitorGraphSize,
+		#1f1f1f,
+		dataInSamplesClone,
+		"Received data sampling",
+		"Data rate (in)",
+		_debugNetworkHandlerRef.data_rate_sample_interval,
+		_debugNetworkHandlerRef.data_in_samples_max_value,
+		"kb/s",
+		#2bbbf2,
+		undefined
+	);
+	
+	ds_list_add(monitorElements,
+		monitorTitleElement,
+		monitorPingGraphElement,
+		monitorPacketLossGraphElement,
+		monitorDataOutGraphElement,
+		monitorDataInGraphElement
+	);
+	
+	monitorWindow.AddChildElements(monitorElements);
+	return monitorWindow;
+}

--- a/world-against-us/scripts/CreateWindowDebugMonitorNetwork/CreateWindowDebugMonitorNetwork.yy
+++ b/world-against-us/scripts/CreateWindowDebugMonitorNetwork/CreateWindowDebugMonitorNetwork.yy
@@ -1,0 +1,11 @@
+{
+  "resourceType": "GMScript",
+  "resourceVersion": "1.0",
+  "name": "CreateWindowDebugMonitorNetwork",
+  "isCompatibility": false,
+  "isDnD": false,
+  "parent": {
+    "name": "DebugMonitor",
+    "path": "folders/Scripts/Game/GUI/DebugMonitor.yy",
+  },
+}

--- a/world-against-us/scripts/DebugMonitorNetworkHandler/DebugMonitorNetworkHandler.gml
+++ b/world-against-us/scripts/DebugMonitorNetworkHandler/DebugMonitorNetworkHandler.gml
@@ -1,0 +1,44 @@
+function DebugMonitorNetworkHandler() constructor
+{
+	// PING
+	ping_samples = [];
+	ping_samples_max_count = 300;
+	ping_samples_max_value = 1;
+	ping_sample_interval = 1000;
+	
+	// OVER TIME PACKET LOSS COUNT
+	packet_loss_samples = [];
+	packet_loss_samples_max_value = 1;
+	
+	// DATA RATE
+	data_rate_sample_interval = 1000;
+	// DATA IN RATE
+	data_in_samples = [];
+	data_in_samples_max_count = 300;
+	data_in_samples_max_value = 1;
+	
+	
+	// DATA OUT RATE
+	data_out_samples = [];
+	data_out_samples_max_count = 300;
+	data_out_samples_max_value = 1;
+	
+	static ResetNetworkDebugMonitoring = function()
+	{
+		// PING
+		ping_samples = [];
+		ping_samples_max_value = 1;
+		
+		// OVER TIME PACKET LOSS COUNT
+		packet_loss_samples = [];
+		packet_loss_samples_max_value = 1;
+		
+		// DATA IN RATE
+		data_in_samples = [];
+		data_in_samples_max_value = 1;
+		
+		// DATA OUT RATE
+		data_out_samples = [];
+		data_out_samples_max_value = 1;
+	}
+}

--- a/world-against-us/scripts/DebugMonitorNetworkHandler/DebugMonitorNetworkHandler.yy
+++ b/world-against-us/scripts/DebugMonitorNetworkHandler/DebugMonitorNetworkHandler.yy
@@ -1,0 +1,11 @@
+{
+  "resourceType": "GMScript",
+  "resourceVersion": "1.0",
+  "name": "DebugMonitorNetworkHandler",
+  "isCompatibility": false,
+  "isDnD": false,
+  "parent": {
+    "name": "DebugMonitor",
+    "path": "folders/Scripts/Game/Data/DebugMonitor.yy",
+  },
+}

--- a/world-against-us/scripts/EnumGUIView/EnumGUIView.gml
+++ b/world-against-us/scripts/EnumGUIView/EnumGUIView.gml
@@ -7,6 +7,7 @@ enum GUI_VIEW
 	SaveSelection,
 	// DEBUG MONITOR
 	DebugMonitorGame,
+	DebugMonitorNetwork,
 	// PLAYER OVERVIEW
 	PlayerBackpack,
 	PlayerHealthStatus,

--- a/world-against-us/scripts/NetworkConnectionSampler/NetworkConnectionSampler.gml
+++ b/world-against-us/scripts/NetworkConnectionSampler/NetworkConnectionSampler.gml
@@ -50,6 +50,19 @@ function NetworkConnectionSampler() constructor
 			last_data_in_rate = data_in_rate;
 			data_in_rate = 0;
 			
+			// DEBUG MONITOR
+			var monitorHandlerRef = global.DebugMonitorNetworkHandlerRef;
+			
+			if (array_length(monitorHandlerRef.data_out_samples) >= monitorHandlerRef.data_out_samples_max_count) array_shift(monitorHandlerRef.data_out_samples);
+			var dataOutSampleKilobits = BytesToKilobits(last_data_out_rate);
+			array_push(monitorHandlerRef.data_out_samples, dataOutSampleKilobits);
+			monitorHandlerRef.data_out_samples_max_value = max(dataOutSampleKilobits, monitorHandlerRef.data_out_samples_max_value);
+			
+			if (array_length(monitorHandlerRef.data_in_samples) >= monitorHandlerRef.data_in_samples_max_count) array_shift(monitorHandlerRef.data_in_samples);
+			var dataInSampleKilobits = BytesToKilobits(last_data_in_rate);
+			array_push(monitorHandlerRef.data_in_samples, dataInSampleKilobits);
+			monitorHandlerRef.data_in_samples_max_value = max(dataInSampleKilobits, monitorHandlerRef.data_in_samples_max_value);
+			
 			data_rate_sample_timer.StartTimer();
 		}
 	}
@@ -88,7 +101,6 @@ function NetworkConnectionSampler() constructor
 	
 	static ProcessPingSample = function(_receivedPingSample)
 	{
-		ping = current_time - _receivedPingSample;
 		if (_receivedPingSample < last_update_time)
 		{
 			var consoleLog = string(
@@ -97,6 +109,13 @@ function NetworkConnectionSampler() constructor
 				last_update_time
 			);
 			global.ConsoleHandlerRef.AddConsoleLog(CONSOLE_LOG_TYPE.WARNING, consoleLog);
+		} else {
+			ping = current_time - _receivedPingSample;
+			
+			var monitorHandlerRef = global.DebugMonitorNetworkHandlerRef;
+			if (array_length(monitorHandlerRef.ping_samples) >= monitorHandlerRef.ping_samples_max_count) array_shift(monitorHandlerRef.ping_samples);
+			array_push(monitorHandlerRef.ping_samples, ping);
+			monitorHandlerRef.ping_samples_max_value = max(ping, monitorHandlerRef.ping_samples_max_value);	
 		}
 		
 		// STOP TIMEOUT TIMER


### PR DESCRIPTION
Client
Added debug monitor handler for networking to handle network-related debug sampling.
Added global value for DebugMonitorNetworkHandler ref.
Added debug monitor GUI view and game window with functionalities to draw network-related debug sampling graphs.
Added callback input function to debug monitor GUI state.
Enhanced NetworkConnectionSampler to sample network metrics like ping and data in/out rates, and NetworkPacketTracker to sample packet loss counts (over time).