### PR TITLE
Add multiplayer-related debug monitor graphs

### DIFF
--- a/world-against-us/objects/objDebugMonitor/Create_0.gml
+++ b/world-against-us/objects/objDebugMonitor/Create_0.gml
@@ -1,2 +1,3 @@
 debugMonitorGameHandler = new DebugMonitorGameHandler();
 debugMonitorNetworkHandler = new DebugMonitorNetworkHandler();
+debugMonitorMultiplayerHandler = new DebugMonitorMultiplayerHandler();

--- a/world-against-us/objects/objDebugMonitor/Step_0.gml
+++ b/world-against-us/objects/objDebugMonitor/Step_0.gml
@@ -1,4 +1,8 @@
 debugMonitorGameHandler.Update();
+if (global.MultiplayerMode)
+{
+	debugMonitorMultiplayerHandler.Update();	
+}
 
 if (keyboard_check_released(KEY_DEBUG_MONITOR))
 {

--- a/world-against-us/objects/objglobals/Create_0.gml
+++ b/world-against-us/objects/objglobals/Create_0.gml
@@ -125,6 +125,7 @@ global.ObjMouse = noone;
 global.ConsoleHandlerRef = undefined;
 global.DebugMonitorGameHandlerRef = undefined;
 global.DebugMonitorNetworkHandlerRef = undefined;
+global.DebugMonitorMultiplayerHandlerRef = undefined;
 global.NotificationHandlerRef = undefined;
 global.ObjNetwork = noone;
 global.NetworkHandlerRef = undefined;

--- a/world-against-us/objects/objglobals/Other_10.gml
+++ b/world-against-us/objects/objglobals/Other_10.gml
@@ -9,6 +9,7 @@ global.NotificationHandlerRef = instance_exists(objNotification) ? instance_find
 global.ConsoleHandlerRef = instance_exists(objConsole) ? instance_find(objConsole, 0).consoleHandler : undefined;
 global.DebugMonitorGameHandlerRef = instance_exists(objDebugMonitor) ? instance_find(objDebugMonitor, 0).debugMonitorGameHandler : undefined;
 global.DebugMonitorNetworkHandlerRef = instance_exists(objDebugMonitor) ? instance_find(objDebugMonitor, 0).debugMonitorNetworkHandler : undefined;
+global.DebugMonitorMultiplayerHandlerRef = instance_exists(objDebugMonitor) ? instance_find(objDebugMonitor, 0).debugMonitorMultiplayerHandler : undefined;
 global.ObjNetwork = instance_exists(objNetwork) ? instance_find(objNetwork, 0) : noone;
 global.NetworkHandlerRef = instance_exists(objNetwork) ? instance_find(objNetwork, 0).networkHandler : undefined;
 global.NetworkRegionHandlerRef = (!is_undefined(global.NetworkHandlerRef)) ? global.NetworkHandlerRef.network_region_handler : undefined;

--- a/world-against-us/scripts/CallbackGUIStateInputDebugMonitor/CallbackGUIStateInputDebugMonitor.gml
+++ b/world-against-us/scripts/CallbackGUIStateInputDebugMonitor/CallbackGUIStateInputDebugMonitor.gml
@@ -15,6 +15,12 @@ function CallbackGUIStateInputDebugMonitor()
 			global.GUIStateHandlerRef.RequestGUIView(GUI_VIEW.DebugMonitorNetwork, [
 				CreateWindowDebugMonitorNetwork(GAME_WINDOW.DebugMonitor, -1, global.DebugMonitorNetworkHandlerRef)
 			], GUI_CHAIN_RULE.OverwriteAll);
+		} else if (keyboard_check_released(ord("3")))
+		{
+			// OPEN MULTIPLAYER MONITORING
+			global.GUIStateHandlerRef.RequestGUIView(GUI_VIEW.DebugMonitorMultiplayer, [
+				CreateWindowDebugMonitorMultiplayer(GAME_WINDOW.DebugMonitor, -1, global.DebugMonitorMultiplayerHandlerRef)
+			], GUI_CHAIN_RULE.OverwriteAll);
 		}
 	}
 }

--- a/world-against-us/scripts/CreateWindowDebugMonitorMultiplayer/CreateWindowDebugMonitorMultiplayer.gml
+++ b/world-against-us/scripts/CreateWindowDebugMonitorMultiplayer/CreateWindowDebugMonitorMultiplayer.gml
@@ -1,0 +1,74 @@
+function CreateWindowDebugMonitorMultiplayer(_gameWindowId, _zIndex, _debugMultiplayerHandlerRef)
+{
+	var windowSize = new Size(global.GUIW, global.GUIH);
+	var windowStyle = new GameWindowStyle(c_black, 1);
+	var monitorWindow = new GameWindow(
+		_gameWindowId,
+		new Vector2(0, 0),
+		windowSize, windowStyle, _zIndex
+	);
+	
+	var monitorElements = ds_list_create();
+	
+	var monitorTitlePosition = new Vector2(10, 10);
+	var monitorTitleElement = new WindowText(
+		"MonitorTitle",
+		monitorTitlePosition,
+		undefined, undefined,
+		"Debug Monitor - Multiplayer", font_default, fa_left, fa_top, c_white, 1
+	);
+	
+	var monitorGraphPosition = new Vector2(80, 150);
+	var monitorGraphSize = new Size(800, 300);
+	var networkEntitiesSamplesClone = [];
+	array_copy(
+		networkEntitiesSamplesClone, 0,
+		_debugMultiplayerHandlerRef.network_entities_samples, 0,
+		array_length(_debugMultiplayerHandlerRef.network_entities_samples)
+	);
+	var monitorNetworkEntitiesGraphElement = new WindowDebugMonitorGraph(
+		"MonitorNetworkEntitiesGraph",
+		monitorGraphPosition,
+		monitorGraphSize,
+		#1f1f1f,
+		networkEntitiesSamplesClone,
+		"Network entity count sampling",
+		"Entity count (active)",
+		_debugMultiplayerHandlerRef.network_entities_sample_interval,
+		_debugMultiplayerHandlerRef.network_entities_samples_max_value,
+		"count",
+		#2bbbf2,
+		#f2a035
+	);
+	
+	monitorGraphPosition = new Vector2(970, 150);
+	var fastTravelTimeSamplesClone = [];
+	array_copy(
+		fastTravelTimeSamplesClone, 0,
+		_debugMultiplayerHandlerRef.fast_travel_time_samples, 0,
+		array_length(_debugMultiplayerHandlerRef.fast_travel_time_samples)
+	);
+	var monitorFastTravelTimeGraphElement = new WindowDebugMonitorGraph(
+		"MonitorFastTravelTimeGraph",
+		monitorGraphPosition,
+		monitorGraphSize,
+		#1f1f1f,
+		fastTravelTimeSamplesClone,
+		"Overall fast travel time sampling",
+		"Fast travel time",
+		undefined,
+		_debugMultiplayerHandlerRef.fast_travel_time_samples_max_value,
+		"ms",
+		#2bbbf2,
+		#f2a035
+	);
+	
+	ds_list_add(monitorElements,
+		monitorTitleElement,
+		monitorNetworkEntitiesGraphElement,
+		monitorFastTravelTimeGraphElement,
+	);
+	
+	monitorWindow.AddChildElements(monitorElements);
+	return monitorWindow;
+}

--- a/world-against-us/scripts/CreateWindowDebugMonitorMultiplayer/CreateWindowDebugMonitorMultiplayer.yy
+++ b/world-against-us/scripts/CreateWindowDebugMonitorMultiplayer/CreateWindowDebugMonitorMultiplayer.yy
@@ -1,0 +1,11 @@
+{
+  "resourceType": "GMScript",
+  "resourceVersion": "1.0",
+  "name": "CreateWindowDebugMonitorMultiplayer",
+  "isCompatibility": false,
+  "isDnD": false,
+  "parent": {
+    "name": "DebugMonitor",
+    "path": "folders/Scripts/Game/GUI/DebugMonitor.yy",
+  },
+}

--- a/world-against-us/scripts/DebugMonitorMultiplayerHandler/DebugMonitorMultiplayerHandler.gml
+++ b/world-against-us/scripts/DebugMonitorMultiplayerHandler/DebugMonitorMultiplayerHandler.gml
@@ -1,0 +1,82 @@
+function DebugMonitorMultiplayerHandler() constructor
+{
+	// NETWORK ENTITIES
+	network_entities_samples = [];
+	network_entities_samples_max_count = 300;
+	network_entities_samples_max_value = 1;
+	network_entities_sample_interval = 2000;
+	network_entities_sample_timer = new Timer(network_entities_sample_interval);
+	network_entities_sample_timer.StartTimer();
+	
+	// FAST TRAVEL TIME
+	fast_travel_time_samples = [];
+	fast_travel_time_samples_max_count = 100;
+	fast_travel_time_samples_max_value = 1;
+	fast_travel_sample_start_time = 0;
+	
+	static Update = function()
+	{
+		// UPDATE NETWORK ENTITY SAMPLING
+		network_entities_sample_timer.Update();
+		if (network_entities_sample_timer.IsTimerStopped())
+		{
+			// SAMPLE NETWORK ENTITY COUNT
+			var networkEntityCount = 0;
+			var regionHandler = global.NetworkRegionObjectHandlerRef;
+			// LOCAL INSTANCE OBJECTS
+			if (instance_exists(global.InstancePlayer)) networkEntityCount++;
+			var localPlayers = regionHandler.local_players;
+			if (!is_undefined(localPlayers)) networkEntityCount += ds_list_size(localPlayers);
+			var localPatrols = regionHandler.local_patrols;
+			if (!is_undefined(localPatrols)) networkEntityCount += ds_list_size(localPatrols);
+			if (!is_undefined(regionHandler.scouting_drone)) networkEntityCount++;
+			// CONTAINERS
+			if (!is_undefined(regionHandler.requested_container_access)) networkEntityCount++;
+			// SCOUTING STREAM
+			var mapDataHandler = global.MapDataHandlerRef;
+			if (!is_undefined(mapDataHandler.active_operations_scout_stream))
+			{
+				// OPERATIONS CENTER INSTANCE
+				networkEntityCount++;
+				// SCOUTING DRONE
+				if (!is_undefined(mapDataHandler.scouting_drone)) networkEntityCount++;
+				// MONITORED INSTANCE OBJECTS
+				if (!is_undefined(mapDataHandler.dynamic_map_data)) networkEntityCount += ds_list_size(mapDataHandler.dynamic_map_data);
+			}
+			
+			if (array_length(network_entities_samples) >= network_entities_samples_max_count) array_shift(network_entities_samples);
+			array_push(network_entities_samples, networkEntityCount);
+			network_entities_samples_max_value = max(networkEntityCount, network_entities_samples_max_value);
+				
+			// RESTART SAMPLE TIMER
+			network_entities_sample_timer.StartTimer();
+		}
+	}
+	
+	
+	static StartFastTravelTimeSampling = function()
+	{
+		fast_travel_sample_start_time = current_time;	
+	}
+	
+	static EndFastTravelTimeSampling = function()
+	{
+		if (array_length(fast_travel_time_samples) >= fast_travel_time_samples_max_count) array_shift(fast_travel_time_samples);
+		var fastTravelTimeSample = floor(current_time - fast_travel_sample_start_time);
+		array_push(fast_travel_time_samples, fastTravelTimeSample);
+		fast_travel_time_samples_max_value = max(fastTravelTimeSample, fast_travel_time_samples_max_value);
+		fast_travel_sample_start_time = 0;
+	}
+	
+	static ResetMultiplayerDebugMonitoring = function()
+	{
+		// NETWORK ENTITIES
+		network_entities_samples = [];
+		network_entities_samples_max_value = 1;
+		
+		// FAST TRAVEL TIME
+		fast_travel_time_samples = [];
+		fast_travel_time_samples_max_value = 1;
+		fast_travel_sample_start_time = 0;
+	}
+}

--- a/world-against-us/scripts/DebugMonitorMultiplayerHandler/DebugMonitorMultiplayerHandler.yy
+++ b/world-against-us/scripts/DebugMonitorMultiplayerHandler/DebugMonitorMultiplayerHandler.yy
@@ -1,0 +1,11 @@
+{
+  "resourceType": "GMScript",
+  "resourceVersion": "1.0",
+  "name": "DebugMonitorMultiplayerHandler",
+  "isCompatibility": false,
+  "isDnD": false,
+  "parent": {
+    "name": "DebugMonitor",
+    "path": "folders/Scripts/Game/Data/DebugMonitor.yy",
+  },
+}

--- a/world-against-us/scripts/EnumGUIView/EnumGUIView.gml
+++ b/world-against-us/scripts/EnumGUIView/EnumGUIView.gml
@@ -8,6 +8,7 @@ enum GUI_VIEW
 	// DEBUG MONITOR
 	DebugMonitorGame,
 	DebugMonitorNetwork,
+	DebugMonitorMultiplayer,
 	// PLAYER OVERVIEW
 	PlayerBackpack,
 	PlayerHealthStatus,

--- a/world-against-us/scripts/NetworkPacketHandler/NetworkPacketHandler.gml
+++ b/world-against-us/scripts/NetworkPacketHandler/NetworkPacketHandler.gml
@@ -244,6 +244,9 @@ function NetworkPacketHandler() constructor
 											{
 												global.NotificationHandlerRef.AddNotificationPlayerReturnedToCamp(global.NetworkHandlerRef.player_tag);
 											}
+											
+											// DEBUG MONITOR
+											global.DebugMonitorMultiplayerHandlerRef.EndFastTravelTimeSampling();
 												
 											// RESPOND WITH ACKNOWLEDGMENT TO SUCCESS FAST TRAVEL REQUEST
 											isPacketHandled = global.NetworkHandlerRef.QueueAcknowledgmentResponse();

--- a/world-against-us/scripts/RoomChangeHandler/RoomChangeHandler.gml
+++ b/world-against-us/scripts/RoomChangeHandler/RoomChangeHandler.gml
@@ -85,6 +85,9 @@ function RoomChangeHandler() constructor
 				if (global.NetworkHandlerRef.AddPacketToQueue(networkPacket))
 				{
 					global.PlayerCharacter.is_fast_traveling = true;
+					
+					// DEBUG MONITOR
+					global.DebugMonitorMultiplayerHandlerRef.StartFastTravelTimeSampling();
 				} else {
 					show_debug_message("Failed to request fast travel");	
 				}


### PR DESCRIPTION
Client
Added debug monitor handler struct for multiplayer to handle multiplayer-related debug sampling.
Enhanced objDebugMonitor to call Update function from debug monitor multiplayer handler on Step Event.
Added global value for DebugMonitorMultiplayerHandler ref.
Added debug monitor GUI view and game window with functionalities to draw multiplayer-related debug sampling graphs.
Enhanced CallbackGUIStateInputDebugMonitor function to include new debug monitor GUI view option.
Improved RoomChangeHandler and NetworkPacketHandler structs to sample multiplayer fast travel times for debug monitoring.