### PR TITLE
Bugfix debug monitor memory dump log feed

### DIFF
--- a/world-against-us/scripts/CreateWindowDebugMonitorNetwork/CreateWindowDebugMonitorNetwork.gml
+++ b/world-against-us/scripts/CreateWindowDebugMonitorNetwork/CreateWindowDebugMonitorNetwork.gml
@@ -54,7 +54,7 @@ function CreateWindowDebugMonitorNetwork(_gameWindowId, _zIndex, _debugNetworkHa
 		monitorGraphSize,
 		#1f1f1f,
 		packetDropSamplesClone,
-		"Over time packet loss count sampling",
+		"Overall packet loss count sampling",
 		"Total count",
 		undefined,
 		_debugNetworkHandlerRef.packet_loss_samples_max_value,

--- a/world-against-us/scripts/DebugMonitorGameHandler/DebugMonitorGameHandler.gml
+++ b/world-against-us/scripts/DebugMonitorGameHandler/DebugMonitorGameHandler.gml
@@ -49,7 +49,7 @@ function DebugMonitorGameHandler() constructor
 			
 			// SAMPLE MEMORY USAGE
 			if (array_length(memory_usage_samples) >= fps_samples_max_count) array_shift(memory_usage_samples);
-			var memoryDump = debug_event("DumpMemory");
+			var memoryDump = debug_event("DumpMemory", true);
 			var memoryUsageSample = floor((memoryDump.totalUsed ?? 0) * 0.000001);
 			array_push(memory_usage_samples, memoryUsageSample);
 			memory_usage_samples_max_value = max(memoryUsageSample, memory_usage_samples_max_value);


### PR DESCRIPTION
Client
Disabled console logging on "dump memory" debug event.
Tweaked packet loss graph title in debug monitor network view.