### PR TITLE
Optimize console window data refresh when adding console logs

### DIFF
--- a/world-against-us/scripts/ConsoleHandler/ConsoleHandler.gml
+++ b/world-against-us/scripts/ConsoleHandler/ConsoleHandler.gml
@@ -51,15 +51,19 @@ function ConsoleHandler() constructor
 		}
 		ds_list_add(console_logs, consoleLog);
 		
-		var consoleWindow = global.GameWindowHandlerRef.GetWindowById(GAME_WINDOW.Console);
-		if (!is_undefined(consoleWindow))
+		var currentGUIState = global.GUIStateHandlerRef.GetGUIState();
+		if (currentGUIState.index == GUI_STATE.Console)
 		{
-			var consoleLogListElement = consoleWindow.GetChildElementById("ConsoleLogList");
-			if (!is_undefined(consoleLogListElement))
+			var consoleWindow = global.GameWindowHandlerRef.GetWindowById(GAME_WINDOW.Console);
+			if (!is_undefined(consoleWindow))
 			{
-				var consoleMessages = ds_list_create();
-				ds_list_copy(consoleMessages, global.ConsoleHandlerRef.console_logs);
-				consoleLogListElement.UpdateDataCollection(consoleMessages);
+				var consoleLogListElement = consoleWindow.GetChildElementById("ConsoleLogList");
+				if (!is_undefined(consoleLogListElement))
+				{
+					var consoleMessages = ds_list_create();
+					ds_list_copy(consoleMessages, global.ConsoleHandlerRef.console_logs);
+					consoleLogListElement.UpdateDataCollection(consoleMessages);
+				}
 			}
 		}
 	}

--- a/world-against-us/scripts/CreateWindowConsole/CreateWindowConsole.gml
+++ b/world-against-us/scripts/CreateWindowConsole/CreateWindowConsole.gml
@@ -2,7 +2,7 @@ function CreateWindowConsole(_gameWindowId, _zIndex, _consoleMessages)
 {
 	var windowSize = new Size(global.GUIW, global.GUIH);
 	var windowStyle = new GameWindowStyle(c_black, 0.8);
-	var mapWindow = new GameWindow(
+	var consoleWindow = new GameWindow(
 		_gameWindowId,
 		new Vector2(0, 0),
 		windowSize, windowStyle, _zIndex
@@ -44,6 +44,6 @@ function CreateWindowConsole(_gameWindowId, _zIndex, _consoleMessages)
 		consoleLogElement
 	);
 	
-	mapWindow.AddChildElements(consoleElements);
-	return mapWindow;
+	consoleWindow.AddChildElements(consoleElements);
+	return consoleWindow;
 }


### PR DESCRIPTION
Client
Optimized logic in ConsoleHandler struct to attempt refreshing console window only when it's open when adding console logs.
Fixed typos in variable names in CreateWindowConsole function.