### PR TITLE
Bugfix missing player autopilot key binding

### DIFF
--- a/world-against-us/objects/objglobals/Create_0.gml
+++ b/world-against-us/objects/objglobals/Create_0.gml
@@ -72,6 +72,7 @@ randomise();
 #macro KEY_ESC_MENU	vk_escape
 #macro KEY_CONSOLE vk_f1
 #macro KEY_DEBUG_MONITOR vk_f5
+#macro KEY_DEBUG_PLAYER_AUTOPILOT vk_f9
 #macro KEY_PLAYER_OVERVIEW vk_tab
 #macro KEY_JOURNAL ord("J")
 #macro KEY_MAP ord("M")


### PR DESCRIPTION
Client
Fixed missing global key binding macro value for debug player autopilot.