### PR TITLE
Refactor remote player movement and position network sync

### DIFF
--- a/nodejs-server/src/modules/network/NetworkPacketBuilder.js
+++ b/nodejs-server/src/modules/network/NetworkPacketBuilder.js
@@ -230,6 +230,29 @@ export default class NetworkPacketBuilder {
               isPayloadWritten = true;
             }
             break;
+          case MESSAGE_TYPE.REMOTE_DATA_POSITION:
+            {
+              const player = payload;
+              const bufferRemotePosition = Buffer.allocUnsafe(
+                BITWISE.BIT32 + BITWISE.BIT32
+              ).fill(0);
+              let offset = 0;
+              bufferRemotePosition.writeUInt32LE(player.position.X, offset);
+              offset += BITWISE.BIT32;
+              bufferRemotePosition.writeUInt32LE(player.position.Y, offset);
+
+              const bufferRemoteNetworkId = Buffer.from(
+                player.network_id,
+                "utf8"
+              );
+
+              this.payloadBuffer = Buffer.concat([
+                bufferRemotePosition,
+                bufferRemoteNetworkId,
+              ]);
+              isPayloadWritten = true;
+            }
+            break;
           case MESSAGE_TYPE.REMOTE_DATA_MOVEMENT_INPUT:
             {
               let deviceInputCompress = 0;

--- a/nodejs-server/src/modules/network/NetworkPacketHandler.js
+++ b/nodejs-server/src/modules/network/NetworkPacketHandler.js
@@ -141,7 +141,27 @@ export default class NetworkPacketHandler {
               if (player !== undefined) {
                 player.position = newPosition;
                 // Set new snapshot required flag
-                instance.isNewSnapshotRequired = true;
+                //instance.isNewSnapshotRequired = true;
+
+                // Broadcast about updated player position data
+                const clientsToBroadcast =
+                  this.clientHandler.getClientsToBroadcastInstance(
+                    instance.instanceId,
+                    client.uuid
+                  );
+                const broadcastNetworkPacketHeader = new NetworkPacketHeader(
+                  MESSAGE_TYPE.REMOTE_DATA_POSITION,
+                  client.uuid
+                );
+                const broadcastNetworkPacket = new NetworkPacket(
+                  broadcastNetworkPacketHeader,
+                  player.toJSONStruct(),
+                  PACKET_PRIORITY.DEFAULT
+                );
+                this.networkHandler.broadcast(
+                  broadcastNetworkPacket,
+                  clientsToBroadcast
+                );
 
                 // Acknowledgment is sent with new snapshot
                 isPacketHandled = true;

--- a/nodejs-server/src/modules/network_packets/NetworkPacketDeliveryPolicies.js
+++ b/nodejs-server/src/modules/network_packets/NetworkPacketDeliveryPolicies.js
@@ -17,6 +17,15 @@ networkPacketDeliveryPolicies[MESSAGE_TYPE.INVALID_REQUEST] =
 networkPacketDeliveryPolicies[MESSAGE_TYPE.SERVER_ERROR] =
   new NetworkPacketDeliveryPolicy(false, false, false, false, false);
 
+networkPacketDeliveryPolicies[MESSAGE_TYPE.PLAYER_DATA_POSITION] =
+  new NetworkPacketDeliveryPolicy(false, true, true, true, false);
+networkPacketDeliveryPolicies[MESSAGE_TYPE.PLAYER_DATA_MOVEMENT_INPUT] =
+  new NetworkPacketDeliveryPolicy(false, true, true, true, false);
+networkPacketDeliveryPolicies[MESSAGE_TYPE.REMOTE_DATA_POSITION] =
+  new NetworkPacketDeliveryPolicy(false, true, true, true, false);
+networkPacketDeliveryPolicies[MESSAGE_TYPE.REMOTE_DATA_MOVEMENT_INPUT] =
+  new NetworkPacketDeliveryPolicy(false, true, true, true, false);
+
 // Default
 networkPacketDeliveryPolicies[MESSAGE_TYPE.LENGTH] =
   new NetworkPacketDeliveryPolicy();

--- a/world-against-us/objects/objnetwork/Draw_0.gml
+++ b/world-against-us/objects/objnetwork/Draw_0.gml
@@ -1,0 +1,4 @@
+if (global.DEBUGMODE)
+{
+	networkHandler.Draw();
+}

--- a/world-against-us/objects/objnetwork/objNetwork.yy
+++ b/world-against-us/objects/objnetwork/objNetwork.yy
@@ -9,6 +9,7 @@
     {"resourceType":"GMEvent","resourceVersion":"1.0","name":"","collisionObjectId":null,"eventNum":3,"eventType":7,"isDnD":false,},
     {"resourceType":"GMEvent","resourceVersion":"1.0","name":"","collisionObjectId":null,"eventNum":5,"eventType":7,"isDnD":false,},
     {"resourceType":"GMEvent","resourceVersion":"1.0","name":"","collisionObjectId":null,"eventNum":0,"eventType":1,"isDnD":false,},
+    {"resourceType":"GMEvent","resourceVersion":"1.0","name":"","collisionObjectId":null,"eventNum":0,"eventType":8,"isDnD":false,},
   ],
   "managed": true,
   "overriddenProperties": [],

--- a/world-against-us/scripts/GenerateAutopilotMovementInput/GenerateAutopilotMovementInput.gml
+++ b/world-against-us/scripts/GenerateAutopilotMovementInput/GenerateAutopilotMovementInput.gml
@@ -47,6 +47,4 @@ function GenerateAutopilotMovementInput(movementInput) {
 		movementInput.key_right = false;
 		movementInput.key_left = true;
 	}
-	
-	show_debug_message(string(movementInput));
 }

--- a/world-against-us/scripts/GenerateAutopilotMovementInput/GenerateAutopilotMovementInput.yy
+++ b/world-against-us/scripts/GenerateAutopilotMovementInput/GenerateAutopilotMovementInput.yy
@@ -6,6 +6,6 @@
   "isDnD": false,
   "parent": {
     "name": "Autopilot",
-    "path": "folders/Scripts/World/Character/AI/Autopilot.yy",
+    "path": "folders/Scripts/Game/Data/AI/Autopilot.yy",
   },
 }

--- a/world-against-us/scripts/InstanceObject/InstanceObject.gml
+++ b/world-against-us/scripts/InstanceObject/InstanceObject.gml
@@ -31,7 +31,7 @@ function InstanceObject(_sprite_index, _object_index, _position) constructor
 	{
 		start_position = position.Clone();
 		target_position = _targetPosition;
-		interpolation_timer.setting_time = _interpolationTime + (global.NetworkConnectionSamplerRef.ping ?? 0);
+		interpolation_timer.setting_time = _interpolationTime;
 		interpolation_timer.StartTimer();
 	}
 	

--- a/world-against-us/scripts/NetworkHandler/NetworkHandler.gml
+++ b/world-against-us/scripts/NetworkHandler/NetworkHandler.gml
@@ -78,6 +78,11 @@ function NetworkHandler() constructor
 		}
 	}
 	
+	static Draw = function()
+	{
+		network_region_handler.Draw();	
+	}
+	
 	static PrepareAndSendNetworkPacket = function(_networkPacket)
 	{
 		var isNetworkPacketSent = false;

--- a/world-against-us/scripts/NetworkPacketDeliveryPolicyHandler/NetworkPacketDeliveryPolicyHandler.gml
+++ b/world-against-us/scripts/NetworkPacketDeliveryPolicyHandler/NetworkPacketDeliveryPolicyHandler.gml
@@ -14,6 +14,11 @@ function NetworkPacketDeliveryPolicyHandler() constructor
 		ds_map_add(delivery_policies, MESSAGE_TYPE.INVALID_REQUEST, new NetworkPacketDeliveryPolicy(false, false, false, false, false));
 		ds_map_add(delivery_policies, MESSAGE_TYPE.SERVER_ERROR, new NetworkPacketDeliveryPolicy(false, false, false, false, false));
 		
+		ds_map_add(delivery_policies, MESSAGE_TYPE.PLAYER_DATA_POSITION, new NetworkPacketDeliveryPolicy(false, true, true, true, false));
+		ds_map_add(delivery_policies, MESSAGE_TYPE.PLAYER_DATA_MOVEMENT_INPUT, new NetworkPacketDeliveryPolicy(false, true, true, true, false));
+		ds_map_add(delivery_policies, MESSAGE_TYPE.REMOTE_DATA_POSITION, new NetworkPacketDeliveryPolicy(false, true, true, true, false));
+		ds_map_add(delivery_policies, MESSAGE_TYPE.REMOTE_DATA_MOVEMENT_INPUT, new NetworkPacketDeliveryPolicy(false, true, true, true, false));
+		
 		// DEFAULT
 		ds_map_add(
 			delivery_policies, MESSAGE_TYPE.ENUM_LENGTH,

--- a/world-against-us/scripts/NetworkPacketHandler/NetworkPacketHandler.gml
+++ b/world-against-us/scripts/NetworkPacketHandler/NetworkPacketHandler.gml
@@ -118,25 +118,23 @@ function NetworkPacketHandler() constructor
 					} break;
 					case MESSAGE_TYPE.REMOTE_DATA_POSITION:
 					{
-						// TODO: Remove this function, replaced with instance snapshot
-						// Parse this elsewhere
-						var remoteDataPosition = payload[$ "remote_data_position"];
-						if (!is_undefined(remoteDataPosition))
+						var remoteInstanceObject = payload;
+						if (!is_undefined(remoteInstanceObject))
 						{
-							//global.NetworkRegionObjectHandlerRef.UpdateRegionRemotePosition(remoteDataPosition);
+							// TODO: Polish client side interpolation / input simulation
+							global.NetworkRegionObjectHandlerRef.UpdateRegionRemotePosition(remoteInstanceObject);
+							isPacketHandled = true;
 						}
-						isPacketHandled = true;
 					} break;
 					case MESSAGE_TYPE.REMOTE_DATA_MOVEMENT_INPUT:
 					{
-						// Parse this elsewhere
 						var remoteDataMovementInput = payload;
 						if (!is_undefined(remoteDataMovementInput))
 						{
-							// TODO: Fix client side interpolation / input simulation
-							//global.NetworkRegionObjectHandlerRef.UpdateRegionRemoteInput(remoteDataMovementInput);
+							// TODO: Polish client side interpolation / input simulation
+							global.NetworkRegionObjectHandlerRef.UpdateRegionRemoteInput(remoteDataMovementInput);
+							isPacketHandled = true;
 						}
-						isPacketHandled = true;
 					} break;
 					case MESSAGE_TYPE.REMOTE_LEFT_THE_INSTANCE:
 					{

--- a/world-against-us/scripts/NetworkPacketParser/NetworkPacketParser.gml
+++ b/world-against-us/scripts/NetworkPacketParser/NetworkPacketParser.gml
@@ -173,6 +173,16 @@ function NetworkPacketParser() constructor
 							parsedRemotePlayerTag
 						);
 					} break;
+					case MESSAGE_TYPE.REMOTE_DATA_POSITION:
+					{
+						var parsedRemotePositionX = buffer_read(_msg, buffer_u32);
+						var parsedRemotePositionY = buffer_read(_msg, buffer_u32);
+						var parsedRemoteClientId = buffer_read(_msg, buffer_string);
+						var parsedRemotePosition = ScaleIntValuesToFloatVector2(parsedRemotePositionX, parsedRemotePositionY);
+						var remoteInstanceData = new InstanceObject(object_get_sprite(objPlayer), objPlayer, parsedRemotePosition);
+						remoteInstanceData.network_id = parsedRemoteClientId;
+						parsedPayload = remoteInstanceData;
+					} break;
 					case MESSAGE_TYPE.REMOTE_DATA_MOVEMENT_INPUT:
 					{
 			            var parsedDeviceInputCompress = buffer_read(_msg, buffer_u8);

--- a/world-against-us/scripts/NetworkRegionHandler/NetworkRegionHandler.gml
+++ b/world-against-us/scripts/NetworkRegionHandler/NetworkRegionHandler.gml
@@ -19,6 +19,11 @@ function NetworkRegionHandler() constructor
 		network_region_object_handler.Update();
 	}
 	
+	static Draw = function()
+	{
+		network_region_object_handler.Draw();	
+	}
+	
 	static IsClientRegionOwner = function()
 	{
 		return (global.NetworkHandlerRef.client_id == owner_client);

--- a/world-against-us/scripts/NetworkRegionObjectHandler/NetworkRegionObjectHandler.gml
+++ b/world-against-us/scripts/NetworkRegionObjectHandler/NetworkRegionObjectHandler.gml
@@ -97,6 +97,14 @@ function NetworkRegionObjectHandler() constructor
 			}
 		}
 		
+		// INTERPOLATE REMOTE PLAYER MOVEMENT
+		var playerCount = ds_list_size(local_players);
+		for (var i = 0; i < playerCount; i++)
+		{
+			var playerInstanceObject = local_players[| i];
+			playerInstanceObject.InterpolateMovement();
+		}
+		
 		// INTERPOLATE SCOUTING DRONE MOVEMENT
 		if (!is_undefined(scouting_drone))
 		{
@@ -282,6 +290,29 @@ function NetworkRegionObjectHandler() constructor
 			}
 		}*/
 	}
+	
+	static UpdateRegionRemotePosition = function(_remoteInstanceObject)
+	{
+		var playerInstanceObject = GetPlayerInstanceObjectById(_remoteInstanceObject.network_id);
+		if (!is_undefined(playerInstanceObject))
+		{
+			var positionThreshold = 50;
+			var distance = point_distance(
+				_remoteInstanceObject.position.X,
+				_remoteInstanceObject.position.Y,
+				playerInstanceObject.position.X,
+				playerInstanceObject.position.Y
+			);
+			if (distance > positionThreshold)
+			{
+				var playerInstanceRef = playerInstanceObject.instance_ref;
+				if (instance_exists(playerInstanceRef))
+				{
+					playerInstanceObject.position = new Vector2(playerInstanceRef.x, playerInstanceRef.y);
+					playerInstanceObject.start_position = playerInstanceObject.position;
+					playerInstanceObject.StartInterpolateMovement(_remoteInstanceObject.position, 50);
+				}
+			}
 		}
 	}
 	

--- a/world-against-us/scripts/NetworkRegionObjectHandler/NetworkRegionObjectHandler.gml
+++ b/world-against-us/scripts/NetworkRegionObjectHandler/NetworkRegionObjectHandler.gml
@@ -115,6 +115,24 @@ function NetworkRegionObjectHandler() constructor
 		}
 	}
 	
+	static Draw = function()
+	{
+		// REMOTE PLAYER POSITION ON SERVER
+		var playerCount = ds_list_size(local_players);
+		for (var i = 0; i < playerCount; i++)
+		{
+			var playerInstanceObject = local_players[| i];
+			if (!is_undefined(playerInstanceObject.target_position))
+			{
+				draw_circle_color(
+					playerInstanceObject.target_position.X,
+					playerInstanceObject.target_position.Y,
+					2, c_blue, c_blue, false
+				);
+			}
+		}	
+	}
+	
 	static ValidateRegionContainers = function()
 	{
 		var isContainersValid = true;


### PR DESCRIPTION
Added new delivery policies for 'player data' and 'remote data' related network packets.

Client
Added Draw Event to objNetwork.
Added Draw methods to NetworkRegionHandler and NetworkRegionObjectHandler structs.
Enhanced network region object handler struct with a new method to update remote players' positions in a region.
Improved 'remote data position' related network packet parsing and handling.
Tweaked instance object interpolation movement timer in InstanceObject struct.
Removed some old 'generate autopilot movement' related debug console logs, and refactored project folder structure.

Server
Improved 'remote data position' related network packet building and handling.
Fixed NetworkPacketTracker class to fetch and utilize delivery policies on in-flight network packet tracking.