### PR TITLE
Refactor sync scouting drone position rework multiplayer

### DIFF
--- a/nodejs-server/src/modules/instances/InstanceHandler.js
+++ b/nodejs-server/src/modules/instances/InstanceHandler.js
@@ -3,6 +3,7 @@ import WORLD_MAP_LOCATION_HIERARCHY from "../world_map/WorldMapLocationHierarchy
 import MESSAGE_TYPE from "../network/MessageType.js";
 import PACKET_PRIORITY from "../network/PacketPriority.js";
 
+import NetworkQueueEntry from "../network/NetworkQueueEntry.js";
 import NetworkPacketHeader from "../network_packets/NetworkPacketHeader.js";
 import NetworkPacket from "../network_packets/NetworkPacket.js";
 
@@ -305,6 +306,19 @@ export default class InstanceHandler {
               // TODO: Proper error handling
               ConsoleHandler.Log(
                 `Failed to reset owner for an instance with ID: ${instanceId}`
+              );
+            }
+          }
+        } else {
+          // End scouting stream
+          if (this.activeOperationsScoutStream !== undefined) {
+            const operatingClient = this.networkHandler.clientHandler.getClient(
+              this.activeOperationsScoutStream.operatingClient
+            );
+            if (operatingClient !== undefined) {
+              this.endOperationsScoutStream(
+                this.activeOperationsScoutStream.instanceId,
+                operatingClient
               );
             }
           }

--- a/nodejs-server/src/modules/instances/InstanceHandler.js
+++ b/nodejs-server/src/modules/instances/InstanceHandler.js
@@ -365,6 +365,38 @@ export default class InstanceHandler {
     return isInstanceReleased;
   }
 
+  endOperationsScoutStream(scoutInstanceId, client) {
+    let isScoutStreamEnded = false;
+    if (this.activeOperationsScoutStream !== undefined) {
+      if (this.activeOperationsScoutStream.instanceId === scoutInstanceId) {
+        // Broadcast destroy scouting drone withing scouted instance
+        this.networkHandler.networkPacketHandler.broadcastScoutingDroneDestroy(
+          scoutInstanceId,
+          client
+        );
+
+        // Reset active operations scout stream after broadcast
+        this.activeOperationsScoutStream = undefined;
+
+        // Response with end operations scout stream
+        const networkPacketHeader = new NetworkPacketHeader(
+          MESSAGE_TYPE.END_OPERATIONS_SCOUT_STREAM,
+          client.uuid
+        );
+        const networkPacket = new NetworkPacket(
+          networkPacketHeader,
+          undefined,
+          PACKET_PRIORITY.DEFAULT
+        );
+        this.networkHandler.queueNetworkPacket(
+          new NetworkQueueEntry(networkPacket, [client])
+        );
+        isScoutStreamEnded = true;
+      }
+    }
+    return isScoutStreamEnded;
+  }
+
   deleteInstance(instanceId) {
     let isInstanceDeleted = false;
     if (this.getInstance(instanceId) !== undefined) {

--- a/nodejs-server/src/modules/network/NetworkPacketBuilder.js
+++ b/nodejs-server/src/modules/network/NetworkPacketBuilder.js
@@ -457,6 +457,35 @@ export default class NetworkPacketBuilder {
               isPayloadWritten = this.writeInstanceSnapshotBuffer(payload);
             }
             break;
+          case MESSAGE_TYPE.SCOUTING_DRONE_DATA_POSITION:
+            {
+              const scoutingDrone = payload;
+              const bufferScoutingDroneData = Buffer.allocUnsafe(
+                BITWISE.BIT32 + // Instance ID
+                  BITWISE.BIT32 + // Position X
+                  BITWISE.BIT32 // Position Y
+              ).fill(0);
+
+              let offset = 0;
+              bufferScoutingDroneData.writeUInt32LE(
+                scoutingDrone.instanceId,
+                offset
+              );
+              offset += BITWISE.BIT32;
+              bufferScoutingDroneData.writeUInt32LE(
+                scoutingDrone.position.x,
+                offset
+              );
+              offset += BITWISE.BIT32;
+              bufferScoutingDroneData.writeUInt32LE(
+                scoutingDrone.position.y,
+                offset
+              );
+
+              this.payloadBuffer = bufferScoutingDroneData;
+              isPayloadWritten = true;
+            }
+            break;
           default: {
             this.payloadBuffer = Buffer.from(
               JSON.stringify(payload ?? {}),

--- a/nodejs-server/src/modules/network/NetworkPacketHandler.js
+++ b/nodejs-server/src/modules/network/NetworkPacketHandler.js
@@ -1063,34 +1063,4 @@ export default class NetworkPacketHandler {
       }
     }
   }
-
-  endOperationsScoutStream(scoutInstanceId, client) {
-    let isScoutStreamEnded = false;
-    const activeOperationsScoutStream =
-      this.instanceHandler.activeOperationsScoutStream;
-    if (activeOperationsScoutStream !== undefined) {
-      if (activeOperationsScoutStream.instanceId === scoutInstanceId) {
-        this.instanceHandler.activeOperationsScoutStream = undefined;
-
-        // Broadcast destroy scouting drone withing scouted instance
-        this.broadcastScoutingDroneDestroy(scoutInstanceId, client);
-
-        // Response with end operations scout stream
-        const networkPacketHeader = new NetworkPacketHeader(
-          MESSAGE_TYPE.END_OPERATIONS_SCOUT_STREAM,
-          client.uuid
-        );
-        const networkPacket = new NetworkPacket(
-          networkPacketHeader,
-          undefined,
-          PACKET_PRIORITY.DEFAULT
-        );
-        this.networkHandler.queueNetworkPacket(
-          new NetworkQueueEntry(networkPacket, [client])
-        );
-        isScoutStreamEnded = true;
-      }
-    }
-    return isScoutStreamEnded;
-  }
 }

--- a/nodejs-server/src/modules/network/NetworkPacketHandler.js
+++ b/nodejs-server/src/modules/network/NetworkPacketHandler.js
@@ -828,7 +828,7 @@ export default class NetworkPacketHandler {
 
                   // Broadcast scouting drone leave withing prior scouted instance
                   if (
-                    scoutInstance.instanceId !=
+                    scoutInstance.instanceId !==
                     activeOperationsScoutStream.instanceId
                   ) {
                     // Broadcast destroy scouting drone withing scouted instance
@@ -943,7 +943,7 @@ export default class NetworkPacketHandler {
                   );
 
                   // Response with scouted instance data
-                  const scoutInstanceSnapshot =
+                  /*const scoutInstanceSnapshot =
                     scoutInstance.fetchInstanceSnapshot();
                   const networkPacketHeader = new NetworkPacketHeader(
                     MESSAGE_TYPE.OPERATIONS_SCOUT_STREAM,
@@ -956,14 +956,15 @@ export default class NetworkPacketHandler {
                   );
                   this.networkHandler.queueNetworkPacket(
                     new NetworkQueueEntry(networkPacket, [client])
-                  );
+                  );*/
                   isPacketHandled = true;
                 } else {
                   // End operations scout stream if instance has deleted
-                  isPacketHandled = this.endOperationsScoutStream(
-                    scoutingDrone.instanceId,
-                    client
-                  );
+                  isPacketHandled =
+                    this.instanceHandler.endOperationsScoutStream(
+                      scoutingDrone.instanceId,
+                      client
+                    );
                 }
               }
             }
@@ -973,7 +974,7 @@ export default class NetworkPacketHandler {
           {
             const scoutInstanceId = networkPacket.payload;
             if (scoutInstanceId !== undefined) {
-              isPacketHandled = this.endOperationsScoutStream(
+              isPacketHandled = this.instanceHandler.endOperationsScoutStream(
                 scoutInstanceId,
                 client
               );

--- a/nodejs-server/src/modules/network/NetworkPacketParser.js
+++ b/nodejs-server/src/modules/network/NetworkPacketParser.js
@@ -386,6 +386,19 @@ export default class NetworkPacketParser {
               payload = msg.readUInt32LE(offset);
             }
             break;
+          case MESSAGE_TYPE.SCOUTING_DRONE_DATA_POSITION:
+            {
+              const parsedInstanceId = msg.readUInt32LE(offset);
+              offset += BITWISE.BIT32;
+              const parsedXPos = msg.readUInt32LE(offset);
+              offset += BITWISE.BIT32;
+              const parsedYPos = msg.readUInt32LE(offset);
+              const parsedScoutingDrone = new ScoutingDrone(parsedInstanceId);
+              parsedScoutingDrone.position.x = parsedXPos;
+              parsedScoutingDrone.position.y = parsedYPos;
+              payload = parsedScoutingDrone;
+            }
+            break;
           default: {
             // Default JSON payload parsing
             const jsonString = msg.toString("utf8", offset);

--- a/nodejs-server/src/modules/network_packets/NetworkPacketDeliveryPolicies.js
+++ b/nodejs-server/src/modules/network_packets/NetworkPacketDeliveryPolicies.js
@@ -29,6 +29,9 @@ networkPacketDeliveryPolicies[MESSAGE_TYPE.REMOTE_DATA_MOVEMENT_INPUT] =
 networkPacketDeliveryPolicies[MESSAGE_TYPE.PATROLS_SNAPSHOT_DATA] =
   new NetworkPacketDeliveryPolicy(false, true, true, true, false);
 
+networkPacketDeliveryPolicies[MESSAGE_TYPE.SCOUTING_DRONE_DATA_POSITION] =
+  new NetworkPacketDeliveryPolicy(false, true, true, true, false);
+
 // Default
 networkPacketDeliveryPolicies[MESSAGE_TYPE.LENGTH] =
   new NetworkPacketDeliveryPolicy();

--- a/world-against-us/objects/objDrone/Create_0.gml
+++ b/world-against-us/objects/objDrone/Create_0.gml
@@ -1,7 +1,7 @@
 // INHERIT THE PARENT EVENT
 event_inherited();
 
-depth = 0;
+depth = -(room_height + 100);
 image_xscale = 0.5;
 image_yscale = image_xscale;
 mask_index = SPRITE_NO_MASK;

--- a/world-against-us/objects/objDrone/objDrone.yy
+++ b/world-against-us/objects/objDrone/objDrone.yy
@@ -14,10 +14,7 @@
     "name": "Character",
     "path": "folders/Objects/World/Character.yy",
   },
-  "parentObjectId": {
-    "name": "objBlockParent",
-    "path": "objects/objBlockParent/objBlockParent.yy",
-  },
+  "parentObjectId": null,
   "persistent": false,
   "physicsAngularDamping": 0.1,
   "physicsDensity": 0.5,

--- a/world-against-us/scripts/CreateWindowOperationsCenter/CreateWindowOperationsCenter.gml
+++ b/world-against-us/scripts/CreateWindowOperationsCenter/CreateWindowOperationsCenter.gml
@@ -68,14 +68,6 @@ function CreateWindowOperationsCenter(_gameWindowId, _zIndex)
 		mapInstanceListButton,
 	);
 	
-	// OVERRIDE WINDOW ONOPEN FUNCTION
-	var overrideOnOpen = function()
-	{
-		// TRIGGER MAP UPDATE
-		global.MapDataHandlerRef.is_dynamic_data_updating = true;
-		global.MapDataHandlerRef.map_update_timer.TriggerTimer();
-	}
-	mapWindow.OnOpen = overrideOnOpen;
 	// OVERRIDE WINDOW ONCLOSE FUNCTION
 	var overrideOnClose = function()
 	{
@@ -84,9 +76,6 @@ function CreateWindowOperationsCenter(_gameWindowId, _zIndex)
 			// REQUEST OPERATIONS END SCOURING STREAM
 			if (!is_undefined(global.MapDataHandlerRef.active_operations_scout_stream))
 			{
-				// RESET ACTIVE OPERATIONS SCOUT STREAM
-				global.MapDataHandlerRef.active_operations_scout_stream = undefined;
-				
 				var targetScoutRegion = global.MapDataHandlerRef.target_scout_region;
 				if (!is_undefined(targetScoutRegion))
 				{
@@ -101,14 +90,14 @@ function CreateWindowOperationsCenter(_gameWindowId, _zIndex)
 					{
 						show_debug_message("Unable to queue MESSAGE_TYPE.END_OPERATIONS_SCOUT_STREAM");
 					}
-					
-					// RESET TARGET SCOUT REGION
-					global.MapDataHandlerRef.target_scout_region = undefined;
 				}
+				
+				// RESET ACTIVE OPERATIONS SCOUT STREAM AFTER REQUEST
+				global.MapDataHandlerRef.ResetActiveOperationsScoutStream();
 			}
 			// CLEAR AND CANCEL OPERATIONS SCOUTING STREAM MESSAGES
 			global.NetworkHandlerRef.CancelPacketsSendQueueAndTrackingByMessageType(MESSAGE_TYPE.START_OPERATIONS_SCOUT_STREAM);
-			global.NetworkHandlerRef.CancelPacketsSendQueueAndTrackingByMessageType(MESSAGE_TYPE.OPERATIONS_SCOUT_STREAM);
+			global.NetworkHandlerRef.CancelPacketsSendQueueAndTrackingByMessageType(MESSAGE_TYPE.SCOUTING_DRONE_DATA_POSITION);
 		}
 		
 		// RESET MAP DATA

--- a/world-against-us/scripts/MapDataHandler/MapDataHandler.gml
+++ b/world-against-us/scripts/MapDataHandler/MapDataHandler.gml
@@ -9,6 +9,10 @@ function MapDataHandler() constructor
 	target_scout_region = undefined;
 	active_operations_scout_stream = undefined;
 	scouting_drone = undefined;
+	scouting_drone_position_sync_interval = 500; //ms
+	scouting_drone_position_sync_timer = new Timer(scouting_drone_position_sync_interval);
+	scouting_drone_prev_position = new Vector2(0, 0);
+	scouting_drone_fly_speed = 12;
 	
 	static Update = function()
 	{
@@ -108,31 +112,14 @@ function MapDataHandler() constructor
 	
 	static UpdateDynamicMapData = function()
 	{
-		if (global.MultiplayerMode)
+		/*if (global.MultiplayerMode)
 		{
-			if (!is_undefined(target_scout_region))
-			{
-				// CONTAINER INVENTORY STREAM
-				var scoutingDroneData = new ScoutingDroneData(
-					target_scout_region.region_id,
-					scouting_drone.position
-				);
-				var formatScoutingDroneData = scoutingDroneData.ToJSONStruct();
-				
-				var networkPacketHeader = new NetworkPacketHeader(MESSAGE_TYPE.OPERATIONS_SCOUT_STREAM);
-				var networkPacket = new NetworkPacket(
-					networkPacketHeader,
-					formatScoutingDroneData,
-					PACKET_PRIORITY.DEFAULT,
-					AckTimeoutFuncResend
-				);
-				global.NetworkHandlerRef.AddPacketToQueue(networkPacket);
-			}
+			
 		} else {
 			// TODO: Disabled during prototyping
-			/*dynamic_map_data.icons = GenerateMapIcons(DYNAMIC_MAP_ICON);*/
+			//dynamic_map_data.icons = GenerateMapIcons(DYNAMIC_MAP_ICON);
 			dynamic_map_data.SortIcons();
-		}
+		}*/
 	}
 	
 	static UpdateDynamicMapSimulatedInterpolation = function()
@@ -165,60 +152,154 @@ function MapDataHandler() constructor
 	static SyncDynamicMapData = function(_regionSnapshot)
 	{
 		// TODO: Optimize and simplify this code
-		var worldMapLocation = global.WorldMapLocationData[? target_scout_region.room_index];
-		if (!is_undefined(worldMapLocation))
+		/*if (!is_undefined(target_scout_region))
 		{
-			var patrolPath = worldMapLocation.patrol_path;
-			if (!is_undefined(patrolPath))
+			var worldMapLocation = global.WorldMapLocationData[? target_scout_region.room_index];
+			if (!is_undefined(worldMapLocation))
 			{
-				var banditMapIconStyle = global.MapIconStyleData[? object_get_name(objBandit)];
-				if (!is_undefined(banditMapIconStyle))
+				var patrolPath = worldMapLocation.patrol_path;
+				if (!is_undefined(patrolPath))
 				{
-					var banditSpriteSize = new Size(
-						sprite_get_width(sprBandit),
-						sprite_get_height(sprBandit)
+					var banditMapIconStyle = global.MapIconStyleData[? object_get_name(objBandit)];
+					if (!is_undefined(banditMapIconStyle))
+					{
+						var banditSpriteSize = new Size(
+							sprite_get_width(sprBandit),
+							sprite_get_height(sprBandit)
+						);
+						// PATCH EXISTENT PATROL MAP ICONS
+						var dynamicIconCount = ds_list_size(dynamic_map_data.icons);
+						for (var i = 0; i < dynamicIconCount; i++)
+						{
+							var dynamicMapIcon = dynamic_map_data.icons[| i];
+							if (!is_undefined(dynamicMapIcon))
+							{
+								var existentPatrolIndex = undefined;
+								var patrolCount = array_length(_regionSnapshot.local_patrols);
+								for (var j = 0; j < patrolCount; j++)
+								{
+									var patrol = _regionSnapshot.local_patrols[@ j];
+									if (!is_undefined(patrol))
+									{
+										if (dynamicMapIcon.simulated_instance_object.network_id == patrol.patrol_id &&
+											dynamicMapIcon.simulated_instance_object.obj_index == objBandit)
+										{
+											existentPatrolIndex = j;
+											break;
+										}
+									}
+								}
+						
+								if (!is_undefined(existentPatrolIndex))
+								{
+									var patrol = _regionSnapshot.local_patrols[@ existentPatrolIndex];								
+									var patrolPosition = new Vector2(
+										path_get_x(patrolPath, patrol.route_progress),
+										path_get_y(patrolPath, patrol.route_progress)
+									);
+									// USE LOCAL POSITION IF OUTSIDE THE ROUTE
+									if (patrol.position.X != 0 && patrol.position.Y != 0)
+									{
+										patrolPosition = patrol.position;
+									}
+									// TODO: Fix interpolation
+									dynamicMapIcon.simulated_instance_object.position = patrolPosition;
+									dynamicMapIcon.simulated_instance_object.StartInterpolateMovement(patrolPosition, MAP_DATA_UPDATE_INTERVAL);
+									array_delete(_regionSnapshot.local_patrols, existentPatrolIndex, 1);
+									patrolCount = array_length(_regionSnapshot.local_patrols);
+								} else {
+									// DELETE OUTDATED PATROL MAP ICONS
+									if (dynamicMapIcon.object_name == object_get_name(objBandit))
+									{
+										ds_list_delete(dynamic_map_data.icons, i--);
+										dynamicIconCount = ds_list_size(dynamic_map_data.icons);
+									}
+								}
+							} else {
+								// DELETE UNDEFINED MAP ICONS
+								ds_list_delete(dynamic_map_data.icons, i--);
+								dynamicIconCount = ds_list_size(dynamic_map_data.icons);
+							}
+						}
+						// ADD NEW PATROL MAP ICONS
+						var newPatrolIconCount = array_length(_regionSnapshot.local_patrols);
+						for (var i = 0; i < newPatrolIconCount; i++)
+						{
+							var patrol = _regionSnapshot.local_patrols[@ i];
+							if (!is_undefined(patrol))
+							{
+								var patrolPosition = new Vector2(
+									path_get_x(patrolPath, patrol.route_progress),
+									path_get_y(patrolPath, patrol.route_progress)
+								);
+								var positionWithOffset = new Vector2(
+									patrolPosition.X - (banditSpriteSize.w * 0.5),
+									patrolPosition.Y - (banditSpriteSize.h)
+								);
+								var mapIcon = new MapIcon(
+									object_get_name(objBandit),
+									// TOP-LEFT CORNER TO DRAW RECTANGLE
+									positionWithOffset,
+									patrolPosition,
+									banditSpriteSize,
+									banditMapIconStyle,
+									1
+								);
+								mapIcon.simulated_instance_object = new InstanceObject(
+									object_get_sprite(objBandit),
+									objBandit,
+									patrolPosition
+								);
+								mapIcon.simulated_instance_object.network_id = patrol.patrol_id;
+								ds_list_add(dynamic_map_data.icons, mapIcon);
+							}
+						}
+					}
+				}
+			
+				var playerMapIconStyle = global.MapIconStyleData[? object_get_name(objPlayer)];
+				if (!is_undefined(playerMapIconStyle))
+				{
+					var playerSpriteSize = new Size(
+						sprite_get_width(sprSoldierOriginal),
+						sprite_get_height(sprSoldierOriginal)
 					);
-					// PATCH EXISTENT PATROL MAP ICONS
+					// PATCH EXISTENT PLAYER MAP ICONS
 					var dynamicIconCount = ds_list_size(dynamic_map_data.icons);
 					for (var i = 0; i < dynamicIconCount; i++)
 					{
 						var dynamicMapIcon = dynamic_map_data.icons[| i];
 						if (!is_undefined(dynamicMapIcon))
 						{
-							var existentPatrolIndex = undefined;
-							var patrolCount = array_length(_regionSnapshot.local_patrols);
-							for (var j = 0; j < patrolCount; j++)
+							var existentPlayerIndex = undefined;
+							var playerCount = array_length(_regionSnapshot.local_players);
+							for (var j = 0; j < playerCount; j++)
 							{
-								var patrol = _regionSnapshot.local_patrols[@ j];
-								if (!is_undefined(patrol))
+								var player = _regionSnapshot.local_players[@ j];
+								if (!is_undefined(player))
 								{
-									if (dynamicMapIcon.simulated_instance_object.network_id == patrol.patrol_id &&
-										dynamicMapIcon.simulated_instance_object.obj_index == objBandit)
+									if (dynamicMapIcon.simulated_instance_object.network_id == player.network_id &&
+										dynamicMapIcon.simulated_instance_object.obj_index == objPlayer)
 									{
-										existentPatrolIndex = j;
+										existentPlayerIndex = j;
 										break;
 									}
 								}
 							}
 						
-							if (!is_undefined(existentPatrolIndex))
+							if (!is_undefined(existentPlayerIndex))
 							{
-								var patrol = _regionSnapshot.local_patrols[@ existentPatrolIndex];								
-								var patrolPosition = new Vector2(
-									path_get_x(patrolPath, patrol.route_progress),
-									path_get_y(patrolPath, patrol.route_progress)
+								var player = _regionSnapshot.local_players[@ existentPlayerIndex];								
+								var playerPosition = new Vector2(
+									player.position.X,
+									player.position.Y
 								);
-								// USE LOCAL POSITION IF OUTSIDE THE ROUTE
-								if (patrol.local_position.X != 0 && patrol.local_position.Y != 0)
-								{
-									patrolPosition = patrol.local_position;
-								}
-								dynamicMapIcon.simulated_instance_object.StartInterpolateMovement(patrolPosition, 300);
-								array_delete(_regionSnapshot.local_patrols, existentPatrolIndex, 1);
-								patrolCount = array_length(_regionSnapshot.local_patrols);
+								dynamicMapIcon.simulated_instance_object.StartInterpolateMovement(playerPosition, MAP_DATA_UPDATE_INTERVAL);
+								array_delete(_regionSnapshot.local_players, existentPlayerIndex, 1);
+								playerCount = array_length(_regionSnapshot.local_players);
 							} else {
-								// DELETE OUTDATED PATROL MAP ICONS
-								if (dynamicMapIcon.object_name == object_get_name(objBandit))
+								// DELETE OUTDATED PLAYER MAP ICONS
+								if (dynamicMapIcon.object_name == object_get_name(objPlayer))
 								{
 									ds_list_delete(dynamic_map_data.icons, i--);
 									dynamicIconCount = ds_list_size(dynamic_map_data.icons);
@@ -230,133 +311,84 @@ function MapDataHandler() constructor
 							dynamicIconCount = ds_list_size(dynamic_map_data.icons);
 						}
 					}
-					// ADD NEW PATROL MAP ICONS
-					var newPatrolIconCount = array_length(_regionSnapshot.local_patrols);
-					for (var i = 0; i < newPatrolIconCount; i++)
+					// ADD NEW PLAYER MAP ICONS
+					var newPlayerIconCount = array_length(_regionSnapshot.local_players);
+					for (var i = 0; i < newPlayerIconCount; i++)
 					{
-						var patrol = _regionSnapshot.local_patrols[@ i];
-						if (!is_undefined(patrol))
+						var player = _regionSnapshot.local_players[@ i];
+						if (!is_undefined(player))
 						{
-							var patrolPosition = new Vector2(
-								path_get_x(patrolPath, patrol.route_progress),
-								path_get_y(patrolPath, patrol.route_progress)
+							var playerPosition = new Vector2(
+								player.position.X,
+								player.position.Y
 							);
 							var positionWithOffset = new Vector2(
-								patrolPosition.X - (banditSpriteSize.w * 0.5),
-								patrolPosition.Y - (banditSpriteSize.h)
+								playerPosition.X - (playerSpriteSize.w * 0.5),
+								playerPosition.Y - (playerSpriteSize.h)
 							);
 							var mapIcon = new MapIcon(
 								object_get_name(objBandit),
 								// TOP-LEFT CORNER TO DRAW RECTANGLE
 								positionWithOffset,
-								patrolPosition,
-								banditSpriteSize,
-								banditMapIconStyle,
+								playerPosition,
+								playerSpriteSize,
+								playerMapIconStyle,
 								1
 							);
 							mapIcon.simulated_instance_object = new InstanceObject(
-								object_get_sprite(objBandit),
-								objBandit,
-								patrolPosition
+								object_get_sprite(objPlayer),
+								objPlayer,
+								playerPosition
 							);
-							mapIcon.simulated_instance_object.network_id = patrol.patrol_id;
+							mapIcon.simulated_instance_object.network_id = player.network_id;
 							ds_list_add(dynamic_map_data.icons, mapIcon);
 						}
 					}
 				}
 			}
-			
-			var playerMapIconStyle = global.MapIconStyleData[? object_get_name(objPlayer)];
-			if (!is_undefined(playerMapIconStyle))
+			// SORT DYNAMIC MAP ICONS
+			dynamic_map_data.SortIcons();
+		}*/
+	}
+	
+	static UpdateScoutingDronePositionBroadcast = function()
+	{
+		if (!is_undefined(active_operations_scout_stream))
+		{
+			if (!is_undefined(scouting_drone))
 			{
-				var playerSpriteSize = new Size(
-					sprite_get_width(sprSoldierOriginal),
-					sprite_get_height(sprSoldierOriginal)
-				);
-				// PATCH EXISTENT PLAYER MAP ICONS
-				var dynamicIconCount = ds_list_size(dynamic_map_data.icons);
-				for (var i = 0; i < dynamicIconCount; i++)
+				scouting_drone_position_sync_timer.Update();
+				if ((scouting_drone.position.X != scouting_drone_prev_position.X) ||
+					(scouting_drone.position.Y != scouting_drone_prev_position.Y))
 				{
-					var dynamicMapIcon = dynamic_map_data.icons[| i];
-					if (!is_undefined(dynamicMapIcon))
+					if (scouting_drone_position_sync_timer.IsTimerStopped())
 					{
-						var existentPlayerIndex = undefined;
-						var playerCount = array_length(_regionSnapshot.local_players);
-						for (var j = 0; j < playerCount; j++)
-						{
-							var player = _regionSnapshot.local_players[@ j];
-							if (!is_undefined(player))
-							{
-								if (dynamicMapIcon.simulated_instance_object.network_id == player.network_id &&
-									dynamicMapIcon.simulated_instance_object.obj_index == objPlayer)
-								{
-									existentPlayerIndex = j;
-									break;
-								}
-							}
-						}
-						
-						if (!is_undefined(existentPlayerIndex))
-						{
-							var player = _regionSnapshot.local_players[@ existentPlayerIndex];								
-							var playerPosition = new Vector2(
-								player.position.X,
-								player.position.Y
-							);
-							dynamicMapIcon.simulated_instance_object.StartInterpolateMovement(playerPosition, 300);
-							array_delete(_regionSnapshot.local_players, existentPlayerIndex, 1);
-							playerCount = array_length(_regionSnapshot.local_players);
-						} else {
-							// DELETE OUTDATED PLAYER MAP ICONS
-							if (dynamicMapIcon.object_name == object_get_name(objPlayer))
-							{
-								ds_list_delete(dynamic_map_data.icons, i--);
-								dynamicIconCount = ds_list_size(dynamic_map_data.icons);
-							}
-						}
-					} else {
-						// DELETE UNDEFINED MAP ICONS
-						ds_list_delete(dynamic_map_data.icons, i--);
-						dynamicIconCount = ds_list_size(dynamic_map_data.icons);
-					}
-				}
-				// ADD NEW PLAYER MAP ICONS
-				var newPlayerIconCount = array_length(_regionSnapshot.local_players);
-				for (var i = 0; i < newPlayerIconCount; i++)
-				{
-					var player = _regionSnapshot.local_players[@ i];
-					if (!is_undefined(player))
-					{
-						var playerPosition = new Vector2(
-							player.position.X,
-							player.position.Y
+						// UPDATE PREVIOUS POSITION
+						scouting_drone_prev_position.X = scouting_drone.position.X;
+						scouting_drone_prev_position.Y = scouting_drone.position.Y;
+							
+						// BROADCAST SCOUTING DRONE POSITION
+						var scoutingDroneData = new ScoutingDroneData(
+							target_scout_region.region_id,
+							scouting_drone.position
 						);
-						var positionWithOffset = new Vector2(
-							playerPosition.X - (playerSpriteSize.w * 0.5),
-							playerPosition.Y - (playerSpriteSize.h)
+						var formatScoutingDroneData = scoutingDroneData.ToJSONStruct();
+				
+						var networkPacketHeader = new NetworkPacketHeader(MESSAGE_TYPE.SCOUTING_DRONE_DATA_POSITION);
+						var networkPacket = new NetworkPacket(
+							networkPacketHeader,
+							formatScoutingDroneData,
+							PACKET_PRIORITY.DEFAULT,
+							undefined
 						);
-						var mapIcon = new MapIcon(
-							object_get_name(objBandit),
-							// TOP-LEFT CORNER TO DRAW RECTANGLE
-							positionWithOffset,
-							playerPosition,
-							playerSpriteSize,
-							playerMapIconStyle,
-							1
-						);
-						mapIcon.simulated_instance_object = new InstanceObject(
-							object_get_sprite(objPlayer),
-							objPlayer,
-							playerPosition
-						);
-						mapIcon.simulated_instance_object.network_id = player.network_id;
-						ds_list_add(dynamic_map_data.icons, mapIcon);
+						global.NetworkHandlerRef.AddPacketToQueue(networkPacket);
+								
+						// RESTART POSITION SYNC TIMER
+						scouting_drone_position_sync_timer.StartTimer();
 					}
 				}
 			}
 		}
-		// SORT DYNAMIC MAP ICONS
-		dynamic_map_data.SortIcons();
 	}
 	
 	static GenerateStaticMapData = function()
@@ -464,11 +496,15 @@ function MapDataHandler() constructor
 		dynamic_map_data.ClearIcons();
 	}
 	
-	static ResetMapData = function()
+	static ResetActiveOperationsScoutStream = function()
 	{
-		target_scout_region = undefined;
 		active_operations_scout_stream = undefined;
+		target_scout_region = undefined;
+		
 		scouting_drone = undefined;
+		scouting_drone_position_sync_timer.StopTimer();
+	}
+	
 		
 		is_dynamic_data_updating = false;
 		map_update_timer.StopTimer();	

--- a/world-against-us/scripts/MapDataHandler/MapDataHandler.gml
+++ b/world-against-us/scripts/MapDataHandler/MapDataHandler.gml
@@ -16,17 +16,26 @@ function MapDataHandler() constructor
 	
 	static Update = function()
 	{
-		if (is_dynamic_data_updating)
+		if (!is_undefined(target_scout_region))
 		{
-			map_update_timer.Update();
-			if (map_update_timer.IsTimerStopped())
+			if (!global.MultiplayerMode)
 			{
-				UpdateDynamicMapData();
-				map_update_timer.StartTimer();
+				if (is_dynamic_data_updating)
+				{
+					map_update_timer.Update();
+					if (map_update_timer.IsTimerStopped())
+					{
+						UpdateDynamicMapData();
+						map_update_timer.StartTimer();
+					}
+				}
+			} else {
+				// UPDATE DYNAMIC MAP SIMULATED INTERPOLATION
+				UpdateDynamicMapSimulatedInterpolation();
+				
+				// UPDATE SCOUTING DRONE POSITION BROADCAST
+				UpdateScoutingDronePositionBroadcast();
 			}
-			
-			// UPDATE DYNAMIC MAP SIMULATED INTERPOLATION
-			UpdateDynamicMapSimulatedInterpolation();
 		}
 	}
 	
@@ -505,6 +514,9 @@ function MapDataHandler() constructor
 		scouting_drone_position_sync_timer.StopTimer();
 	}
 	
+	static ResetMapData = function()
+	{
+		ResetActiveOperationsScoutStream();
 		
 		is_dynamic_data_updating = false;
 		map_update_timer.StopTimer();	

--- a/world-against-us/scripts/NetworkPacketBuilder/NetworkPacketBuilder.gml
+++ b/world-against-us/scripts/NetworkPacketBuilder/NetworkPacketBuilder.gml
@@ -243,18 +243,18 @@ function NetworkPacketBuilder() constructor
 						buffer_write(_networkBuffer, buffer_u32, availableInstance.region_id);
 						isPayloadWritten = true;
 					} break;
-					case MESSAGE_TYPE.OPERATIONS_SCOUT_STREAM:
+					case MESSAGE_TYPE.END_OPERATIONS_SCOUT_STREAM:
+					{
+						var scoutingDroneData = _networkPacketPayload;
+						buffer_write(_networkBuffer, buffer_u32, scoutingDroneData.region_id);
+						isPayloadWritten = true;
+					} break;
+					case MESSAGE_TYPE.SCOUTING_DRONE_DATA_POSITION:
 					{
 						var scoutingDroneData = _networkPacketPayload;
 						buffer_write(_networkBuffer, buffer_u32, scoutingDroneData.region_id);
 						buffer_write(_networkBuffer, buffer_u32, scoutingDroneData.position.X);
 						buffer_write(_networkBuffer, buffer_u32, scoutingDroneData.position.Y);
-						isPayloadWritten = true;
-					} break;
-					case MESSAGE_TYPE.END_OPERATIONS_SCOUT_STREAM:
-					{
-						var scoutingDroneData = _networkPacketPayload;
-						buffer_write(_networkBuffer, buffer_u32, scoutingDroneData.region_id);
 						isPayloadWritten = true;
 					} break;
 					default:

--- a/world-against-us/scripts/NetworkPacketDeliveryPolicyHandler/NetworkPacketDeliveryPolicyHandler.gml
+++ b/world-against-us/scripts/NetworkPacketDeliveryPolicyHandler/NetworkPacketDeliveryPolicyHandler.gml
@@ -21,6 +21,8 @@ function NetworkPacketDeliveryPolicyHandler() constructor
 		
 		ds_map_add(delivery_policies, MESSAGE_TYPE.PATROLS_SNAPSHOT_DATA, new NetworkPacketDeliveryPolicy(false, true, true, true, false));
 		
+		ds_map_add(delivery_policies, MESSAGE_TYPE.SCOUTING_DRONE_DATA_POSITION, new NetworkPacketDeliveryPolicy(false, true, true, true, false));
+		
 		// DEFAULT
 		ds_map_add(
 			delivery_policies, MESSAGE_TYPE.ENUM_LENGTH,

--- a/world-against-us/scripts/NetworkPacketHandler/NetworkPacketHandler.gml
+++ b/world-against-us/scripts/NetworkPacketHandler/NetworkPacketHandler.gml
@@ -446,11 +446,13 @@ function NetworkPacketHandler() constructor
 							}
 							// SET ACTIVE OPERATIONS SCOUT STREAM
 							global.MapDataHandlerRef.active_operations_scout_stream = global.MapDataHandlerRef.target_scout_region;
-							// TRIGGER MAP UPDATE
+							// START SCOUTING DRONE POSITION SYNC TIMER
+							global.MapDataHandlerRef.scouting_drone_position_sync_timer.StartTimer();
+							// START MAP UPDATE
 							global.MapDataHandlerRef.is_dynamic_data_updating = true;
-							global.MapDataHandlerRef.map_update_timer.TriggerTimer();
-							// RESPOND WITH ACKNOWLEDGMENT ON NEXT OPERATION SCOUT STREAM
-							isPacketHandled = true;
+							global.MapDataHandlerRef.map_update_timer.StartTimer();
+							// RESPOND WITH ACKNOWLEDGMENT TO START OPERATIONS SCOUT STREAM
+							isPacketHandled = global.NetworkHandlerRef.QueueAcknowledgmentResponse();
 						}
 					} break;
 					case MESSAGE_TYPE.OPERATIONS_SCOUT_STREAM:
@@ -460,15 +462,15 @@ function NetworkPacketHandler() constructor
 						{
 							// SYNC DYNAMIC REGION MAP DATA
 							global.MapDataHandlerRef.SyncDynamicMapData(regionSnapshot);
-							// RESTART MAP DATA UPDATE TIMER
-							global.MapDataHandlerRef.is_dynamic_data_updating = true;
-							global.MapDataHandlerRef.map_update_timer.StartTimer();
 							// NO NEED FOR SEPARATE ACKNOWLEDGMENT WHILE STREAMING
 							isPacketHandled = true;
 						}
 					} break;
 					case MESSAGE_TYPE.END_OPERATIONS_SCOUT_STREAM:
 					{
+						// RESET OPERATIONS SCOUT STREAM
+						global.MapDataHandlerRef.ResetActiveOperationsScoutStream();
+						
 						// REQUEST GUI STATE RESET
 						global.GUIStateHandlerRef.RequestGUIStateReset();
 						
@@ -495,7 +497,7 @@ function NetworkPacketHandler() constructor
 						var scoutingDroneData = payload;
 						if (!is_undefined(scoutingDroneData))
 						{
-							isPacketHandled = global.NetworkRegionObjectHandlerRef.UpdateScoutingDrone(scoutingDroneData);
+							isPacketHandled = global.NetworkRegionObjectHandlerRef.UpdateScoutingDronePosition(scoutingDroneData);
 						}
 					} break;
 					case MESSAGE_TYPE.DESTROY_SCOUTING_DRONE_DATA:

--- a/world-against-us/scripts/NetworkPacketParser/NetworkPacketParser.gml
+++ b/world-against-us/scripts/NetworkPacketParser/NetworkPacketParser.gml
@@ -138,20 +138,23 @@ function NetworkPacketParser() constructor
 							var regionStruct = parsedStruct[$ "region"] ?? undefined;
 							var parsedRegion = ParseJSONStructToRegion(regionStruct);
 							
-							var parsedScoutingDrone = undefined;
+							var scoutingDroneInstanceObject = undefined;
 							var scoutingDroneStruct = parsedStruct[$ "scouting_drone"] ?? undefined;
 							if (!is_undefined(scoutingDroneStruct))
 							{
-								var parsedPosition = ParseJSONStructToVector2(scoutingDroneStruct[$ "position"] ?? undefined);
-								parsedScoutingDrone = new InstanceObject(
-									object_get_sprite(objDrone),
-									objDrone,
-									parsedPosition
-								);
+								var parsedScoutingDrone = ParseJSONStructToScoutingDroneData(scoutingDroneStruct);
+								if (!is_undefined(parsedScoutingDrone))
+								{
+									scoutingDroneInstanceObject = new InstanceObject(
+										object_get_sprite(objDrone),
+										objDrone,
+										parsedScoutingDrone.position
+									);
+								}
 							}
 							parsedPayload = {
 								region: parsedRegion,
-								scouting_drone: parsedScoutingDrone
+								scouting_drone: scoutingDroneInstanceObject
 							}
 						}
 					} break;

--- a/world-against-us/scripts/NetworkPacketParser/NetworkPacketParser.gml
+++ b/world-against-us/scripts/NetworkPacketParser/NetworkPacketParser.gml
@@ -381,12 +381,14 @@ function NetworkPacketParser() constructor
 					} break;
 					case MESSAGE_TYPE.SCOUTING_DRONE_DATA_POSITION:
 					{
-						var payloadString = buffer_read(_msg, buffer_string);
-						var parsedStruct = json_parse(payloadString);
-						if (parsedStruct != EMPTY_STRUCT)
-						{
-							parsedPayload = ParseJSONStructToScoutingDroneData(parsedStruct);
-						}
+						var parsedRegionId = buffer_read(_msg, buffer_u32);
+						var parsedScoutingDronePositionX = buffer_read(_msg, buffer_u32);
+						var parsedScoutingDronPositionY = buffer_read(_msg, buffer_u32);
+						var parsedScaledScoutingDronePosition = ScaleIntValuesToFloatVector2(parsedScoutingDronePositionX, parsedScoutingDronPositionY);
+						parsedPayload = new ScoutingDroneData(
+							parsedRegionId,
+							parsedScaledScoutingDronePosition
+						);
 					} break;
 					case MESSAGE_TYPE.DESTROY_SCOUTING_DRONE_DATA:
 					{

--- a/world-against-us/scripts/NetworkRegionObjectHandler/NetworkRegionObjectHandler.gml
+++ b/world-against-us/scripts/NetworkRegionObjectHandler/NetworkRegionObjectHandler.gml
@@ -126,14 +126,15 @@ function NetworkRegionObjectHandler() constructor
 		return isDroneSpawned;
 	}
 	
-	static UpdateScoutingDrone = function(_scoutingDroneData)
+	static UpdateScoutingDronePosition = function(_scoutingDroneData)
 	{
 		var isDroneSynced = false;
 		if (!is_undefined(scouting_drone))
 		{
 			if (instance_exists(scouting_drone.instance_ref))
 			{
-				scouting_drone.StartInterpolateMovement(_scoutingDroneData.position, 300);
+				var scoutingDronePositionUpdateInterval = global.MapDataHandlerRef.scouting_drone_position_sync_interval;
+				scouting_drone.StartInterpolateMovement(_scoutingDroneData.position, scoutingDronePositionUpdateInterval);
 				isDroneSynced = true;
 			}
 		}

--- a/world-against-us/scripts/ScoutingDroneData/ScoutingDroneData.gml
+++ b/world-against-us/scripts/ScoutingDroneData/ScoutingDroneData.gml
@@ -11,4 +11,9 @@ function ScoutingDroneData(_region_id, _position) constructor
 			position: formatScaledPosition,
 		}
 	}
+	
+	static OnDestroy = function(_struct = self)
+	{
+		DeleteStruct(_struct.position);
+	}
 }


### PR DESCRIPTION
Added delivery policy for 'scouting drone data position' network packets.

Client
Improved 'scouting drone data position' network packet building, parsing, and handling.
Improved 'sync instance' network packet parsing.
Tweaked Drone object's default depth value, to be drawn top of other in-game objects.
Renamed 'UpdateScoutingDrone' method in NetworkRegionObjectHandler to 'UpdateScoutingDronePosition', and replaced a hard-coded scouting drone interpolation interval value.
Simplified and fixed scouting drone stream logic in CreateWindowOperationsCenter function.
Enhanced MapDataHandler struct with new scouting drone position properties, and with new methods to update scouting drone position broadcasting and to reset active operation scout stream.
Fixed and improved map data update and reset logic in MapDataHandler struct.
Commented out several in-progress code parts and removed some obsolete code.

Server
Improved 'scouting drone data position' network packet building, parsing, and handling.
Moved endOperationsScoutStream method from NetworkPacketHandler class into InstanceHandler, and fixed related function calls in NetworkPacketHandler class.
Fixed InstanceHandler to end active operations stream on instance release.
Fixed operations scout stream ending logic in NetworkPacketHandler and InstanceHandler classes.
Commented out several in-progress code parts.