### PR TITLE
Add player character gear fetching on game save and load

### DIFF
--- a/world-against-us/objects/objRoomLoader/Other_4.gml
+++ b/world-against-us/objects/objRoomLoader/Other_4.gml
@@ -85,7 +85,7 @@ switch (room)
 		room_goto(roomMainMenu);
 	} break;
 	case roomLoadResources: {
-		// INIT NEW PLAYER DATA
+		// INITIALIZE NEW PLAYER SAVE DATA
 		global.PlayerDataHandlerRef.InitPlayerData();
 		
 		// LOAD SAVE FILE

--- a/world-against-us/scripts/CallbackItemSlotPlayerBackpack/CallbackItemSlotPlayerBackpack.gml
+++ b/world-against-us/scripts/CallbackItemSlotPlayerBackpack/CallbackItemSlotPlayerBackpack.gml
@@ -1,12 +1,4 @@
 function CallbackItemSlotPlayerBackpack(_item)
 {
-	if (!is_undefined(_item))
-	{
-		if (!is_undefined(_item.metadata))
-		{
-			global.PlayerBackpack = _item.metadata.inventory;
-		}
-	} else {
-		global.PlayerBackpack = undefined;
-	}
+	global.PlayerBackpack = _item;
 }

--- a/world-against-us/scripts/CharacterHuman/CharacterHuman.gml
+++ b/world-against-us/scripts/CharacterHuman/CharacterHuman.gml
@@ -32,8 +32,6 @@ function CharacterHuman(_name, _type, _race, _behavior, _colliderRef) : Characte
 	// GEAR SLOTS
 	gear = new GearSlots(_name);
 	
-	backpack_slot = new Inventory(string("{0}_Inventory", _name), INVENTORY_TYPE.BackpackSlot, new InventorySize(3, 4), new InventoryFilter([], ["Backpack"], []));
-	
 	static ToJSONStruct = function()
 	{
 		var scaledStamina = ScaleFloatValueToInt(stamina);
@@ -42,9 +40,6 @@ function CharacterHuman(_name, _type, _race, _behavior, _colliderRef) : Characte
 		var scaledEnergy = ScaleFloatValueToInt(energy);
 		
 		var formatGear = (!is_undefined(gear)) ? gear.ToJSONStruct() : undefined;
-		
-		var backpackItem = backpack_slot.GetItemByIndex(0);
-		var formatBackpack = (!is_undefined(backpackItem)) ? backpackItem.ToJSONStruct() : undefined;
 		
 		return {
 			name: name,
@@ -57,18 +52,14 @@ function CharacterHuman(_name, _type, _race, _behavior, _colliderRef) : Characte
 			hydration: scaledHydration,
 			energy: scaledEnergy,
 			
-			gear: formatGear,
-			backpack: formatBackpack
+			gear: formatGear
 		}
 	}
 	
-	static OnDestroy = function()
+	static OnDestroy = function(_struct = self)
 	{
-		ReleaseVariableFromMemory(gear);
-		gear = undefined;
-		
-		ReleaseVariableFromMemory(backpack_slot);
-		backpack_slot = undefined;
+		ReleaseVariableFromMemory(_struct.gear);
+		_struct.gear = undefined;
 	}
 	
 	static Update = function()
@@ -98,25 +89,6 @@ function CharacterHuman(_name, _type, _race, _behavior, _colliderRef) : Characte
 			hydration = clamp(hydration - (thirst_rate / game_get_speed(gamespeed_fps)), 0, max_hydration);
 			energy = clamp(energy - (fatigue_rate / game_get_speed(gamespeed_fps)), 0, max_energy);
 		}
-	}
-	
-	static GetBackpackSlotItem = function()
-	{
-		return backpack_slot.GetItemByIndex(0);
-	}
-	
-	static GetBackpackInventory = function()
-	{
-		var backpackInventory = undefined;
-		var backpackItem = GetBackpackSlotItem();
-		if (!is_undefined(backpackItem))
-		{
-			if (!is_undefined(backpackItem.metadata))
-			{
-				backpackInventory = backpackItem.metadata.inventory;	
-			}
-		}
-		return backpackInventory;
 	}
 	
 	static UseMedicine = function(_item, _targetBodyPartIndex = undefined)

--- a/world-against-us/scripts/CreateWindowPlayerBackpack/CreateWindowPlayerBackpack.gml
+++ b/world-against-us/scripts/CreateWindowPlayerBackpack/CreateWindowPlayerBackpack.gml
@@ -17,12 +17,14 @@ function CreateWindowPlayerBackpack(_gameWindowId, _zIndex)
 		"Backpack", font_large, fa_center, fa_middle, c_white, 1
 		
 	);
+	var backpackItemRef = global.PlayerCharacter.gear.GetItemBySlot(global.PlayerCharacter.gear.backpack);
+	var backpackInventoryRef = (!is_undefined(backpackItemRef)) ? backpackItemRef.metadata.inventory : undefined;
 	var inventoryGrid = new WindowInventoryGrid(
 		"BackpackInventoryGrid",
 		new Vector2(10, 60),
 		new Size(760, 0),
 		undefined,
-		global.PlayerBackpack
+		backpackInventoryRef
 	);
 	
 	// BACKPACK SLOT
@@ -40,7 +42,7 @@ function CreateWindowPlayerBackpack(_gameWindowId, _zIndex)
 		"BackpackSlot",
 		backpackSlotPosition,
 		backpackSlotSize,
-		c_gray, global.PlayerCharacter.backpack_slot,
+		c_gray, global.PlayerCharacter.gear.backpack,
 		CallbackItemSlotPlayerBackpack
 	);
 	

--- a/world-against-us/scripts/GameSaveData/GameSaveData.gml
+++ b/world-against-us/scripts/GameSaveData/GameSaveData.gml
@@ -20,11 +20,9 @@ function GameSaveData(_player_data/*, _game_state_data*/) constructor
 	
 	static InitNewSave = function()
 	{
-		var initCharacter = new GameSaveDataCharacter(EMPTY_STRING, undefined);
 		var initPosition = new Vector2(0, 0);
 		var initLastLocation = new GameSaveDataLastLocation(initPosition, ROOM_DEFAULT);
-		player_data = new GameSaveDataPlayerData(initCharacter, initLastLocation, undefined);
-		//game_state_data;
+		player_data = new GameSaveDataPlayerData(undefined, initLastLocation);
 	}
 	
 	static FetchSaveData = function()
@@ -33,8 +31,7 @@ function GameSaveData(_player_data/*, _game_state_data*/) constructor
 		if (IS_ROOM_IN_GAME_WORLD)
 		{
 			// FETCH CHARACTER
-			player_data.character.name = global.PlayerCharacter.name;
-			player_data.character.backpack = global.PlayerCharacter.GetBackpackSlotItem();
+			player_data.character = global.InstancePlayer.character;
 		
 			// FETCH LAST POSITION
 			player_data.last_location.room_index = ROOM_DEFAULT;

--- a/world-against-us/scripts/GameSaveDataPlayerData/GameSaveDataPlayerData.gml
+++ b/world-against-us/scripts/GameSaveDataPlayerData/GameSaveDataPlayerData.gml
@@ -1,8 +1,7 @@
-function GameSaveDataPlayerData(_character, _last_location, _inventory) constructor
+function GameSaveDataPlayerData(_character, _last_location) constructor
 {
 	character = _character;
 	last_location = _last_location;
-	inventory = _inventory;
 	
 	static OnDestroy = function()
 	{
@@ -11,23 +10,16 @@ function GameSaveDataPlayerData(_character, _last_location, _inventory) construc
 		
 		ReleaseVariableFromMemory(last_location);
 		last_location = undefined;
-		
-		// TODO: Fix primaryWeaponSlot, magazinePockets, and medicinePockets
-		/*ReleaseVariableFromMemory(inventory);
-		inventory = undefined;*/
 	}
 	
 	static ToJSONStruct = function()
 	{
 		var formatCharacterData = character.ToJSONStruct();
 		var formatLastLocation = last_location.ToJSONStruct();
-		// TODO: Write inventory
-		//var formatInventory = inventory.ToJSONStruct();
 		
 		return {
 			character: formatCharacterData,
 			last_location: formatLastLocation,
-			inventory: {}//formatInventory,
 		}
 	}
 }

--- a/world-against-us/scripts/MetadataItemBackpack/MetadataItemBackpack.gml
+++ b/world-against-us/scripts/MetadataItemBackpack/MetadataItemBackpack.gml
@@ -2,8 +2,18 @@ function MetadataItemBackpack(_inventory_size, _max_weight_capacity) : Metadata(
 {
     inventory_size = _inventory_size;
 	max_weight_capacity = _max_weight_capacity;
-	
 	inventory = undefined;
+	is_initialized = false;
+	
+	static Initialize = function(_inventoryId, _inventoryType, _inventoryFilter, _itemLimit, _items = [])
+	{
+		if (!is_initialized)
+		{
+			inventory = new Inventory(_inventoryId, _inventoryType, inventory_size, _inventoryFilter, _itemLimit);
+			inventory.AddMultipleItems(_items);
+			is_initialized = true;
+		}
+	}
 	
 	static ToJSONStruct = function()
 	{
@@ -11,10 +21,5 @@ function MetadataItemBackpack(_inventory_size, _max_weight_capacity) : Metadata(
 		return {
 			inventory_content: formatInventory
 		}
-	}
-	
-	static InitInventory = function(_inventoryId, _inventoryType = INVENTORY_TYPE.BackpackSlot)
-	{
-		inventory = new Inventory(_inventoryId, _inventoryType, inventory_size);
 	}
 }

--- a/world-against-us/scripts/ParseJSONStructToCharacter/ParseJSONStructToCharacter.gml
+++ b/world-against-us/scripts/ParseJSONStructToCharacter/ParseJSONStructToCharacter.gml
@@ -18,21 +18,44 @@ function ParseJSONStructToCharacter(_jsonStruct)
 						characterStruct[$ "name"] ?? undefined,
 						characterStruct[$ "type"] ?? undefined,
 						characterStruct[$ "race"] ?? undefined,
-						characterStruct[$ "behavior"] ?? undefined
+						undefined, // SET BEHAVIOR TO INSTANCE BY OBJECT TYPE
+						undefined // SET COLLIDER TO INSTANCE BY OBJECT TYPE 
 					);
 					
 					// VARYING METADATA
-					if (!is_undefined(characterStruct[$ "stamina"] ?? undefined)) variable_struct_set(parsedCharacter, "stamina", characterStruct[$ "stamina"]);
-					if (!is_undefined(characterStruct[$ "fullness"] ?? undefined)) variable_struct_set(parsedCharacter, "fullness", characterStruct[$ "fullness"]);
-					if (!is_undefined(characterStruct[$ "hydration"] ?? undefined)) variable_struct_set(parsedCharacter, "hydration", characterStruct[$ "hydration"]);
-					if (!is_undefined(characterStruct[$ "energy"] ?? undefined)) variable_struct_set(parsedCharacter, "energy", characterStruct[$ "energy"]);
+					if (!is_undefined(characterStruct[$ "stamina"] ?? undefined)) parsedCharacter.stamina = ScaleIntValueToFloat(characterStruct[$ "stamina"]);
 					
-					if (!is_undefined(characterStruct[$ "backpack"] ?? undefined))
+					if (!is_undefined(characterStruct[$ "fullness"] ?? undefined)) parsedCharacter.fullness = ScaleIntValueToFloat(characterStruct[$ "fullness"]);
+					if (!is_undefined(characterStruct[$ "hydration"] ?? undefined)) parsedCharacter.hydration = ScaleIntValueToFloat(characterStruct[$ "hydration"]);
+					if (!is_undefined(characterStruct[$ "energy"] ?? undefined)) parsedCharacter.energy = ScaleIntValueToFloat(characterStruct[$ "energy"]);
+					
+					var characterGear = characterStruct[$ "gear"] ?? undefined;
+					if (!is_undefined(characterGear))
 					{
-						var parsedBackpack = ParseJSONStructToItem(characterStruct[$ "backpack"]);
-						if (!is_undefined(parsedBackpack))
+						if (!is_undefined(characterGear[$ "helmet"] ?? undefined))
 						{
-							parsedCharacter.backpack_slot.AddItem(parsedBackpack, undefined, false, true);
+							var parsedHelmetItem = ParseJSONStructToItem(characterGear[$ "helmet"] ?? undefined);
+							if (!is_undefined(parsedHelmetItem)) parsedCharacter.gear.helmet.AddItem(parsedHelmetItem, undefined, false);
+						}
+						if (!is_undefined(characterGear[$ "body_armor"] ?? undefined))
+						{
+							var parsedBodyArmorItem = ParseJSONStructToItem(characterGear[$ "body_armor"] ?? undefined);
+							if (!is_undefined(parsedBodyArmorItem)) parsedCharacter.gear.body_armor.AddItem(parsedBodyArmorItem, undefined, false);
+						}
+						if (!is_undefined(characterGear[$ "backpack"] ?? undefined))
+						{
+							var parsedBackpackItem = ParseJSONStructToItem(characterGear[$ "backpack"] ?? undefined);
+							if (!is_undefined(parsedBackpackItem)) parsedCharacter.gear.backpack.AddItem(parsedBackpackItem, undefined, false);
+						}
+						if (!is_undefined(characterGear[$ "primary_weapon"] ?? undefined))
+						{
+							var parsedPrimaryWeaponItem = ParseJSONStructToItem(characterGear[$ "primary_weapon"] ?? undefined);
+							if (!is_undefined(parsedPrimaryWeaponItem)) parsedCharacter.gear.primary_weapon.AddItem(parsedPrimaryWeaponItem, undefined, false);
+						}
+						if (!is_undefined(characterGear[$ "secondary_weapon"] ?? undefined))
+						{
+							var parsedSecondaryWeaponItem = ParseJSONStructToItem(characterGear[$ "secondary_weapon"] ?? undefined);
+							if (!is_undefined(parsedSecondaryWeaponItem)) parsedCharacter.gear.secondary_weapon.AddItem(parsedSecondaryWeaponItem, undefined, false);
 						}
 					}
 				} break;

--- a/world-against-us/scripts/ParseJSONStructToGameSaveDataPlayerData/ParseJSONStructToGameSaveDataPlayerData.gml
+++ b/world-against-us/scripts/ParseJSONStructToGameSaveDataPlayerData/ParseJSONStructToGameSaveDataPlayerData.gml
@@ -7,12 +7,13 @@ function ParseJSONStructToGameSaveDataPlayerData(_jsonStruct)
 		var playerDataStruct = is_string(_jsonStruct) ? json_parse(_jsonStruct) : _jsonStruct;
 		if (variable_struct_names_count(playerDataStruct) <= 0) return playerDataStruct;
 		
-		var parsedCharacter = ParseJSONStructToGameSaveDataCharacter(playerDataStruct[$ "character"]);
+		var parsedCharacter = ParseJSONStructToCharacter(playerDataStruct[$ "character"]);
+		if (!is_undefined(parsedCharacter)) parsedCharacter.behavior = CHARACTER_BEHAVIOR.PLAYER;
 		var parsedLastLocation = ParseJSONStructToGameSaveDataLastLocation(playerDataStruct[$ "last_location"]);
+		
 		parsedPlayerData = new GameSaveDataPlayerData(
 			parsedCharacter,
-			parsedLastLocation,
-			undefined
+			parsedLastLocation
 		);
 	} catch (error)
 	{

--- a/world-against-us/scripts/PlayerDataHandler/PlayerDataHandler.gml
+++ b/world-against-us/scripts/PlayerDataHandler/PlayerDataHandler.gml
@@ -126,29 +126,21 @@ function PlayerDataHandler() constructor
 		{
 			if (gameSaveData != EMPTY_SAVE_DATA)
 			{
-				var gameSaveDataPlayerData = gameSaveData.player_data;
-				if (!is_undefined(gameSaveDataPlayerData))
+				if (!is_undefined(gameSaveData.player_data))
 				{
-					// TODO: Fetch all character data
-					var gameSaveCharacter = gameSaveDataPlayerData.character;
-					if (!is_undefined(gameSaveCharacter))
-					{
-						var gameSaveBackpack = gameSaveCharacter.backpack;
-						if (!is_undefined(gameSaveBackpack))
-						{
-							// FETCH BACKPACK FROM GAME SAVE DATA
-							character.backpack_slot.AddItem(gameSaveBackpack, undefined, false, true);
-							isPlayerDataLoaded = true;
-						}
-					}
+					// DELETE OLD CHARACTER DATA
+					ReleaseVariableFromMemory(character);
+					
+					character = global.GameSaveHandlerRef.game_save_data.player_data.character;
+					isPlayerDataLoaded = true;
 				}
 			} else {
 				// ADD STARTING SUPPLIES
 				var backpack = global.ItemDatabase.GetItemByName("Hiking Backpack");
 				if (!is_undefined(backpack))
 				{
-					backpack.metadata.InitInventory(string("{0}Backpack", character.name), INVENTORY_TYPE.PlayerBackpack);
-					character.backpack_slot.AddItem(backpack, undefined, false, true);
+					backpack.metadata.Initialize(string("{0}Backpack", character.name), INVENTORY_TYPE.PlayerBackpack);
+					character.gear.backpack.AddItem(backpack, undefined, false, true);
 					backpack.metadata.inventory.AddMultipleItems([
 						global.ItemDatabase.GetItemByName("Watering Can"),
 						global.ItemDatabase.GetItemByName("Garden Tools"),
@@ -163,7 +155,7 @@ function PlayerDataHandler() constructor
 			}
 			
 			// SET GLOBAL VARIABLES
-			global.PlayerBackpack = character.GetBackpackInventory();
+			global.PlayerBackpack = character.gear.GetItemBySlot(character.gear.backpack);
 			global.PlayerPrimaryWeaponSlot = primaryWeaponSlot;
 			global.PlayerMagazinePockets = magazinePockets;
 			global.PlayerMedicinePockets = medicinePockets;

--- a/world-against-us/scripts/SpawnHandler/SpawnHandler.gml
+++ b/world-against-us/scripts/SpawnHandler/SpawnHandler.gml
@@ -169,7 +169,7 @@ function SpawnHandler() constructor
 			// SET REMOTE PLAYER CHARACTER
 			playerInstance.character = new CharacterHuman(
 				_remotePlayerInfo.player_tag, CHARACTER_TYPE.Human,
-				CHARACTER_RACE.humanoid, CHARACTER_BEHAVIOR.REMOTE_PLAYER
+				CHARACTER_RACE.humanoid, CHARACTER_BEHAVIOR.REMOTE_PLAYER, undefined
 			);
 			// SET REMOTE PLAYER INSTANCE REF
 			_remotePlayerInstanceObject.instance_ref = playerInstance;


### PR DESCRIPTION
Improvements

- Enhanced initialization logic in MetadataItemBackpack struct, with more consistent method and property naming and simplified logic

Fixes

- Inventory and item references on the window element initialization in the CreateWindowPlayerBackpack script
- Player character backpack gear update logic on the item slot window element callback function call in the CallbackItemSlotPlayerBackpack script. Might remove this logic afterward
- JSON parse logic in the ParseJSONStructToCharacter script to fetch character gear from JSON. Includes fixes in default values of other character struct properties
- Game save data loading logic in the PlayerDataHandler struct to set player character and backpack data properly
- Game save data handling logic in the GameSaveData struct to initialize a new save correctly. Includes fixes in player data fetching when the game saves
- JSON parse logic in the ParseJSONStructToGameSaveDataPlayerData script
- Missing parameter on a CharacterHuman constructor call in the SpawnHandler struct
- Typos in comments in the RoomLoader object

Obsolete

- Removed some obsolete backpack logic from the CharacterHuman struct
- Removed inventory-related obsolete properties and code from the GameSaveDataPlayerData struct