### PR TITLE
Bugfix insufficient item metadata and inventory JSON parsing

### DIFF
--- a/world-against-us/scripts/DatabaseItem/DatabaseItem.gml
+++ b/world-against-us/scripts/DatabaseItem/DatabaseItem.gml
@@ -13,7 +13,7 @@ function DatabaseItem() constructor
 		var itemClone = itemData[? _name].Clone();
 		if (!is_undefined(itemClone))
 		{
-			itemClone.quantity = _quantity
+			itemClone.quantity = min(itemClone.max_stack, _quantity);
 		}
 		
 		return itemClone;

--- a/world-against-us/scripts/InventoryFilter/InventoryFilter.gml
+++ b/world-against-us/scripts/InventoryFilter/InventoryFilter.gml
@@ -13,9 +13,29 @@ function InventoryFilter(_whitelisted_names, _whitelisted_categories, _whitelist
 		};
 	}
 	
+	static Clone = function()
+	{
+		var cloneWhitelistedNames = [];
+		array_copy(cloneWhitelistedNames, 0, whitelisted_names, 0, array_length(whitelisted_names));
+		var cloneWhitelistedCategories = [];
+		array_copy(cloneWhitelistedCategories, 0, whitelisted_categories, 0, array_length(whitelisted_categories));
+		var cloneWhitelistedTypes = [];
+		array_copy(cloneWhitelistedTypes, 0, whitelisted_types, 0, array_length(whitelisted_types));
+		return new InventoryFilter(
+			cloneWhitelistedNames,
+			cloneWhitelistedCategories,
+			cloneWhitelistedTypes
+		);
+	}
+	
 	static OnDestroy = function(_struct = self)
 	{
-		// NO GARBAGE CLEANING
+		ReleaseVariableFromMemory(_struct.whitelisted_names)
+		_struct.whitelisted_names = undefined;
+		ReleaseVariableFromMemory(_struct.whitelisted_categories)
+		_struct.whitelisted_categories = undefined;
+		ReleaseVariableFromMemory(_struct.whitelisted_types)
+		_struct.whitelisted_types = undefined;
 	}
 	
 	static IsItemWhitelisted = function(_item)

--- a/world-against-us/scripts/MetadataItemBackpack/MetadataItemBackpack.gml
+++ b/world-against-us/scripts/MetadataItemBackpack/MetadataItemBackpack.gml
@@ -1,25 +1,45 @@
 function MetadataItemBackpack(_inventory_size, _max_weight_capacity) : Metadata() constructor
 {
-    inventory_size = _inventory_size;
+	inventory_size = _inventory_size;
 	max_weight_capacity = _max_weight_capacity;
 	inventory = undefined;
 	is_initialized = false;
-	
-	static Initialize = function(_inventoryId, _inventoryType, _inventoryFilter, _itemLimit, _items = [])
-	{
-		if (!is_initialized)
-		{
-			inventory = new Inventory(_inventoryId, _inventoryType, inventory_size, _inventoryFilter, _itemLimit);
-			inventory.AddMultipleItems(_items);
-			is_initialized = true;
-		}
-	}
 	
 	static ToJSONStruct = function()
 	{
 		var formatInventory = (!is_undefined(inventory)) ? inventory.ToJSONStruct() : undefined;
 		return {
-			inventory_content: formatInventory
+			inventory: formatInventory
+		}
+	}
+	
+	static Clone = function()
+	{
+		var clone = new MetadataItemBackpack(
+			inventory_size,
+			max_weight_capacity
+		);
+		if (is_initialized)
+		{
+			var cloneInventory = inventory.Clone();
+			clone.Initialize(cloneInventory);
+		}
+		return clone;
+	}
+	
+	static OnDestroy = function(_struct = self)
+	{
+		ReleaseVariableFromMemory(_struct.inventory);
+		_struct.inventory = undefined;
+		
+	}
+	
+	static Initialize = function(_inventory)
+	{
+		if (!is_initialized)
+		{
+			inventory = _inventory;
+			is_initialized = true;
 		}
 	}
 }

--- a/world-against-us/scripts/MetadataItemBullet/MetadataItemBullet.gml
+++ b/world-against-us/scripts/MetadataItemBullet/MetadataItemBullet.gml
@@ -8,9 +8,8 @@ function MetadataItemBullet(_base_damage, _caliber, _fly_speed, _projectile, _tr
 	
 	static ToJSONStruct = function()
 	{
-		return {
-			// NO DYNAMIC METADATA
-		}
+		// NO DYNAMIC METADATA
+		return EMPTY_STRUCT;
 	}
 	
 	static Clone = function()

--- a/world-against-us/scripts/MetadataItemBullet/MetadataItemBullet.gml
+++ b/world-against-us/scripts/MetadataItemBullet/MetadataItemBullet.gml
@@ -6,16 +6,27 @@ function MetadataItemBullet(_base_damage, _caliber, _fly_speed, _projectile, _tr
 	projectile = _projectile;
 	trail_rgba_color = _trail_rgba_color;
 	
-	static OnDestroy = function(_struct = self)
-	{
-		ReleaseVariableFromMemory(_struct.trail_rgba_color);
-		_struct.trail_rgba_color = undefined;
-	}
-	
 	static ToJSONStruct = function()
 	{
 		return {
 			// NO DYNAMIC METADATA
 		}
+	}
+	
+	static Clone = function()
+	{
+		return new MetadataItemBullet(
+			base_damage,
+			caliber,
+			fly_speed,
+			projectile,
+			trail_rgba_color.Clone()
+		);
+	}
+	
+	static OnDestroy = function(_struct = self)
+	{
+		ReleaseVariableFromMemory(_struct.trail_rgba_color);
+		_struct.trail_rgba_color = undefined;
 	}
 }

--- a/world-against-us/scripts/MetadataItemMagazine/MetadataItemMagazine.gml
+++ b/world-against-us/scripts/MetadataItemMagazine/MetadataItemMagazine.gml
@@ -1,7 +1,7 @@
 function MetadataItemMagazine(_caliber, _capacity) : Metadata() constructor
 {
 	caliber = _caliber;
-    capacity = _capacity;
+	capacity = _capacity;
 	bullets = [];
 	
 	static ToJSONStruct = function()
@@ -9,6 +9,22 @@ function MetadataItemMagazine(_caliber, _capacity) : Metadata() constructor
 		return {
 			bullets: bullets
 		}
+	}
+	
+	static Clone = function()
+	{
+		var clone = new MetadataItemMagazine(
+			caliber,
+			capacity
+		);
+		array_copy(clone.bullets, 0, bullets, 0, array_length(bullets));
+		return clone;
+	}
+	
+	static OnDestroy = function(_struct = self)
+	{
+		ReleaseVariableFromMemory(_struct.bullets);
+		_struct.bullets = undefined;
 	}
 	
 	static GetAmmoCount = function()

--- a/world-against-us/scripts/MetadataItemWeapon/MetadataItemWeapon.gml
+++ b/world-against-us/scripts/MetadataItemWeapon/MetadataItemWeapon.gml
@@ -1,19 +1,33 @@
 function MetadataItemWeapon(_fire_rate, _range, _kickback, _weapon_offset, _chamber_pos, _barrel_pos, _right_hand_position, _left_hand_position) : Metadata() constructor
 {
-    fire_rate = _fire_rate;
-    range = _range;
-    kickback = _kickback;
+	fire_rate = _fire_rate;
+	range = _range;
+	kickback = _kickback;
 	weapon_offset = new Vector2(_weapon_offset.X, _weapon_offset.Y);
 	chamber_pos = new Vector2(_chamber_pos.X, _chamber_pos.Y);
 	barrel_pos = new Vector2(_barrel_pos.X, _barrel_pos.Y);
+	// TODO: Remove obsolete properties
 	right_hand_position = new Vector2(_right_hand_position.X, _right_hand_position.Y);
 	left_hand_position = new Vector2(_left_hand_position.X, _left_hand_position.Y);
-	// TODO: isHolstered variable
 	
 	static ToJSONStruct = function()
 	{
-		return {
-			// NO DYNAMIC METADATA
-		}
+		// NO DYNAMIC METADATA
+		return EMPTY_STRUCT;
+	}
+	
+	static Clone = function()
+	{
+		// OVERRIDE THIS FUNCTION
+	}
+	
+	static OnDestroy = function(_struct = self)
+	{
+		ReleaseVariableFromMemory(_struct.weapon_offset);
+		_struct.weapon_offset = undefined;
+		ReleaseVariableFromMemory(_struct.chamber_pos);
+		_struct.chamber_pos = undefined;
+		ReleaseVariableFromMemory(_struct.barrel_pos);
+		_struct.barrel_pos = undefined;
 	}
 }

--- a/world-against-us/scripts/MetadataItemWeaponGun/MetadataItemWeaponGun.gml
+++ b/world-against-us/scripts/MetadataItemWeaponGun/MetadataItemWeaponGun.gml
@@ -1,9 +1,9 @@
 function MetadataItemWeaponGun(_fire_rate, _range, _kickback, _weapon_offset, _chamber_pos, _barrel_pos, _right_hand_position, _left_hand_position, _chamber_type, _caliber, _recoil, _attachment_slots) : MetadataItemWeapon(_fire_rate, _range, _kickback, _weapon_offset, _chamber_pos, _barrel_pos, _right_hand_position, _left_hand_position) constructor
 {
-    chamber_type = _chamber_type;
-    caliber = _caliber;
-    recoil = _recoil;
-    attachment_slots = _attachment_slots;
+	chamber_type = _chamber_type;
+	caliber = _caliber;
+	recoil = _recoil;
+	attachment_slots = _attachment_slots;
 	magazine = undefined;
 	
 	static ToJSONStruct = function()
@@ -12,6 +12,32 @@ function MetadataItemWeaponGun(_fire_rate, _range, _kickback, _weapon_offset, _c
 		return {
 			magazine: formatMagazine
 		}
+	}
+	
+	static Clone = function()
+	{
+		var clone = new MetadataItemWeaponGun(
+			fire_rate,
+			range,
+			kickback,
+			weapon_offset,
+			chamber_pos,
+			barrel_pos,
+			right_hand_position,
+			left_hand_position,
+			chamber_type,
+			caliber,
+			recoil,
+			attachment_slots
+		);
+		clone.magazine = (!is_undefined(magazine)) ? magazine.Clone() : undefined;
+		return clone;
+	}
+	
+	static OnDestroy = function(_struct = self)
+	{
+		ReleaseVariableFromMemory(_struct.magazine);
+		_struct.magazine = undefined;
 	}
 	
 	static GetAmmoCount = function()

--- a/world-against-us/scripts/ParseJSONStructToDatabaseItemMetadata/ParseJSONStructToDatabaseItemMetadata.gml
+++ b/world-against-us/scripts/ParseJSONStructToDatabaseItemMetadata/ParseJSONStructToDatabaseItemMetadata.gml
@@ -128,8 +128,14 @@ function ParseJSONStructToDatabaseItemMetadata(_jsonStruct, _itemCategory, _item
 			} break;
 			case "Backpack":
 			{
+				var jsonInventorySize = metadataStruct[$ "inventory_size"] ?? undefined;
+				if (is_undefined(jsonInventorySize)) return parsedMetadata;
+				var parsedInventorySize = new InventorySize(
+					jsonInventorySize[$ "columns"] ?? undefined,
+					jsonInventorySize[$ "rows"] ?? undefined
+				)
 				parsedMetadata = new MetadataItemBackpack(
-					metadataStruct[$ "inventory_size"] ?? undefined,
+					parsedInventorySize,
 					metadataStruct[$ "max_weight_capacity"] ?? undefined
 				);
 			} break;

--- a/world-against-us/scripts/ParseJSONStructToInventory/ParseJSONStructToInventory.gml
+++ b/world-against-us/scripts/ParseJSONStructToInventory/ParseJSONStructToInventory.gml
@@ -1,32 +1,35 @@
 function ParseJSONStructToInventory(_jsonStruct)
 {
 	var parsedInventory = undefined;
-	
 	try
 	{
 		if (is_undefined(_jsonStruct)) return parsedInventory;
 		var inventoryStruct = is_string(_jsonStruct) ? json_parse(_jsonStruct) : _jsonStruct;
 		if (variable_struct_names_count(inventoryStruct) <= 0) return parsedInventory;
 		
-		parsedInventory = {
-			inventory_id: inventoryStruct[$ "inventory_id"] ?? undefined,
-			inventory_type: inventoryStruct[$ "inventory_type"] ?? undefined,
-			items: []
-		};
-						
-		var itemsArrayStruct = inventoryStruct[$ "items"] ?? [];
-		var itemCount = array_length(itemsArrayStruct);
-		for (var i = 0; i < itemCount; i++)
-		{
-			var itemStruct = itemsArrayStruct[@ i];
-			var item = ParseJSONStructToItem(itemStruct);
-			array_push(parsedInventory.items, item);
-		}
+		var sizeStruct = inventoryStruct[$ "size"];
+		if (is_undefined(sizeStruct)) return parsedInventory;
+		var inventoryFilterStruct = inventoryStruct[$ "inventory_filter"];
+		if (is_undefined(inventoryFilterStruct)) return parsedInventory;
+		
+		var parsedInventorySize = ParseJSONStructToInventorySize(sizeStruct);
+		var parsedInventoryFilter = ParseJSONStructToInventoryFilter(inventoryFilterStruct);
+		var itemCountLimitStruct = inventoryStruct[$ "item_count_limit"] ?? -1;
+		var parsedItemCountLimit = (itemCountLimitStruct == -1) ? infinity : itemCountLimitStruct;
+		parsedInventory = new Inventory(
+			inventoryStruct[$ "inventory_id"] ?? undefined,
+			inventoryStruct[$ "type"] ?? undefined,
+			parsedInventorySize,
+			parsedInventoryFilter,
+			parsedItemCountLimit
+		);
+		var parsedItems = ParseJSONStructToArray(inventoryStruct[$ "items"] ?? [], ParseJSONStructToItem);
+		// POPULATE INVENTORY WITH ITEMS
+		parsedInventory.AddMultipleItems(parsedItems);
 	} catch (error)
 	{
 		show_debug_message(error);
 		show_message(error);
 	}
-	
 	return parsedInventory;
 }

--- a/world-against-us/scripts/ParseJSONStructToInventoryFilter/ParseJSONStructToInventoryFilter.gml
+++ b/world-against-us/scripts/ParseJSONStructToInventoryFilter/ParseJSONStructToInventoryFilter.gml
@@ -1,0 +1,21 @@
+function ParseJSONStructToInventoryFilter(_jsonStruct)
+{
+	var parsedInventoryFilter = undefined;
+	try
+	{
+		if (is_undefined(_jsonStruct)) return parsedInventoryFilter;
+		var inventoryFilterStruct = is_string(_jsonStruct) ? json_parse(_jsonStruct) : _jsonStruct;
+		if (variable_struct_names_count(inventoryFilterStruct) <= 0) return parsedInventoryFilter;
+		
+		parsedInventoryFilter = new InventoryFilter(
+			inventoryFilterStruct[$ "whitelisted_names"] ?? [],
+			inventoryFilterStruct[$ "whitelisted_categories"] ?? [],
+			inventoryFilterStruct[$ "whitelisted_types"] ?? []
+		);
+	} catch (error)
+	{
+		show_debug_message(error);
+		show_message(error);
+	}
+	return parsedInventoryFilter;
+}

--- a/world-against-us/scripts/ParseJSONStructToInventoryFilter/ParseJSONStructToInventoryFilter.yy
+++ b/world-against-us/scripts/ParseJSONStructToInventoryFilter/ParseJSONStructToInventoryFilter.yy
@@ -1,0 +1,13 @@
+{
+  "$GMScript":"v1",
+  "%Name":"ParseJSONStructToInventoryFilter",
+  "isCompatibility":false,
+  "isDnD":false,
+  "name":"ParseJSONStructToInventoryFilter",
+  "parent":{
+    "name":"Inventory",
+    "path":"folders/Scripts/Game/Data/Inventory.yy",
+  },
+  "resourceType":"GMScript",
+  "resourceVersion":"2.0",
+}

--- a/world-against-us/scripts/ParseJSONStructToInventorySize/ParseJSONStructToInventorySize.gml
+++ b/world-against-us/scripts/ParseJSONStructToInventorySize/ParseJSONStructToInventorySize.gml
@@ -1,0 +1,20 @@
+function ParseJSONStructToInventorySize(_jsonStruct)
+{
+	var parsedInventorySize = undefined;
+	try
+	{
+		if (is_undefined(_jsonStruct)) return parsedInventorySize;
+		var inventorySizeStruct = is_string(_jsonStruct) ? json_parse(_jsonStruct) : _jsonStruct;
+		if (variable_struct_names_count(inventorySizeStruct) <= 0) return parsedInventorySize;
+		
+		parsedInventorySize = new InventorySize(
+			inventorySizeStruct[$ "columns"],
+			inventorySizeStruct[$ "rows"]
+		);
+	} catch (error)
+	{
+		show_debug_message(error);
+		show_message(error);
+	}
+	return parsedInventorySize;
+}

--- a/world-against-us/scripts/ParseJSONStructToInventorySize/ParseJSONStructToInventorySize.yy
+++ b/world-against-us/scripts/ParseJSONStructToInventorySize/ParseJSONStructToInventorySize.yy
@@ -1,0 +1,13 @@
+{
+  "$GMScript":"v1",
+  "%Name":"ParseJSONStructToInventorySize",
+  "isCompatibility":false,
+  "isDnD":false,
+  "name":"ParseJSONStructToInventorySize",
+  "parent":{
+    "name":"Inventory",
+    "path":"folders/Scripts/Game/Data/Inventory.yy",
+  },
+  "resourceType":"GMScript",
+  "resourceVersion":"2.0",
+}

--- a/world-against-us/scripts/ParseJSONStructToItemMetadata/ParseJSONStructToItemMetadata.gml
+++ b/world-against-us/scripts/ParseJSONStructToItemMetadata/ParseJSONStructToItemMetadata.gml
@@ -1,17 +1,14 @@
 function ParseJSONStructToItemMetadata(_jsonStruct, _itemData)
 {
-	var parsedMetadata = undefined;
+	// POPULATE METADATA WITH DATABASE VALUES
+	// THEN MODIFY IT WITH VARYING METADATA FROM JSON DATA
+	var parsedMetadata = _itemData.metadata
 	try
 	{
 		if (is_undefined(_jsonStruct)) return parsedMetadata;
 		var metadataStruct = is_string(_jsonStruct) ? json_parse(_jsonStruct) : _jsonStruct;
 		if (variable_struct_names_count(metadataStruct) <= 0) return parsedMetadata;
-		
 		if (is_undefined(_itemData.category)) return parsedMetadata;
-		
-		// POPULATE METADATA WITH DATABASE VALUES
-		// THEN MODIFY IT WITH VARYING METADATA FROM JSON DATA
-		parsedMetadata = _itemData.metadata
 		
 		switch (_itemData.category)
 		{
@@ -66,30 +63,12 @@ function ParseJSONStructToItemMetadata(_jsonStruct, _itemData)
 			} break;
 			case "Backpack":
 			{
-				var inventoryContent = metadataStruct[$ "inventory_content"];
-				if (!is_undefined(inventoryContent))
+				var parsedInventory = ParseJSONStructToInventory(metadataStruct[$ "inventory"]);
+				if (!is_undefined(parsedInventory))
 				{
-					var inventoryId = inventoryContent[$ "inventory_id"] ?? undefined;
-					if (!is_undefined(inventoryId))
-					{
-						var itemsStruct = inventoryContent[$ "items"] ?? [];
-						var parsedItems = ParseJSONStructToArray(itemsStruct ?? undefined, ParseJSONStructToItem);
-						parsedMetadata.Initialize(
-							inventoryId,
-							inventoryContent[$ "inventory_type"] ?? undefined,
-							undefined, // DEFAULT INVENTORY FILTER
-							undefined, // DEFAULT INVENTORY ITEM LIMIT
-							parsedItems
-						);
-					}
+					parsedMetadata.Initialize(parsedInventory);
 				}
 			} break;
-		}
-			
-		if (is_undefined(parsedMetadata))
-		{
-			show_message("ParseMetadataItem : Metadata parse error");
-			throw (string(metadataStruct));
 		}
 	} catch (error) {
 		show_debug_message(error);

--- a/world-against-us/scripts/inventory/Inventory.gml
+++ b/world-against-us/scripts/inventory/Inventory.gml
@@ -1,12 +1,12 @@
-function Inventory(_inventoryId, _type, _size = undefined, _inventoryFilter = undefined, _itemLimit = infinity) constructor
+function Inventory(_inventoryId, _type, _size, _inventoryFilter, _itemCountLimit) constructor
 {
 	inventory_id = _inventoryId
-    items = ds_list_create();
 	type = _type;
-	size = _size ?? new InventorySize(0, 0);
-	inventory_filter = _inventoryFilter ?? new InventoryFilter([], [], []);
-	item_limit = _itemLimit;
+	size = _size;
+	inventory_filter = _inventoryFilter;
+	item_count_limit = _itemCountLimit;
 	
+	items = ds_list_create();
 	grid_data = [];
 	grid = {
 		columns: size.columns,
@@ -24,14 +24,43 @@ function Inventory(_inventoryId, _type, _size = undefined, _inventoryFilter = un
 	
 	static ToJSONStruct = function()
 	{
-		var formatInventoryFilter = (!is_undefined(inventory_filter)) ? inventory_filter.ToJSONStruct() : inventory_filter;
+		var formatSize = size.ToJSONStruct();
+		var formatInventoryFilter = inventory_filter.ToJSONStruct();
 		var formatItems = FormatItemListToJSONArray(items);
 		return {
 			inventory_id: inventory_id,
-			inventory_type: type,
-			items: formatItems,
-			formatInventoryFilter
+			type: type,
+			size: formatSize,
+			inventory_filter: formatInventoryFilter,
+			item_count_limit: (item_count_limit == infinity) ? -1 : item_count_limit,
+			items: formatItems
 		}
+	}
+	
+	static Clone = function()
+	{
+		var cloneSize = size.Clone();
+		var cloneInventoryFilter = inventory_filter.Clone();
+		var clone = new Inventory(
+			inventory_id,
+			type,
+			cloneSize,
+			cloneInventoryFilter,
+			item_count_limit
+		);
+		// COPY ITEMS
+		var itemCount = GetItemCount();
+		for (var i = 0; i < itemCount; i++)
+		{
+			var item = GetItemByIndex(i);
+			clone.AddItem(
+				item,
+				item.grid_index,
+				item.is_rotated,
+				item.is_known
+			);
+		}
+		return clone;
 	}
 	
 	static OnDestroy = function(_struct = self)
@@ -47,17 +76,17 @@ function Inventory(_inventoryId, _type, _size = undefined, _inventoryFilter = un
 	static InitGridData = function()
 	{
 		// RESET GRID DATA
-	    for (var i = 0; i < size.rows; i++) {
-		  for (var j = 0; j < size.columns; j ++) {
-		    grid_data[i, j] = undefined;
-		  }
+		for (var i = 0; i < size.rows; i++) {
+			for (var j = 0; j < size.columns; j ++) {
+				grid_data[i, j] = undefined;
+			}
 		}
 	}
 	
 	static GetItemCount = function()
-    {
+	{
 		return ds_list_size(items);
-    }
+	}
 	
 	static ClearAllItems = function()
 	{
@@ -67,15 +96,15 @@ function Inventory(_inventoryId, _type, _size = undefined, _inventoryFilter = un
 	}
 	
 	static IsItemWhitelisted = function(_item)
-    {
+	{
 		return inventory_filter.IsItemWhitelisted(_item);
-    }
+	}
 
-    static AddItem = function(_item, _new_grid_index = undefined, _new_is_rotated = false, _new_is_known = true)
-    {
+	static AddItem = function(_item, _new_grid_index = undefined, _new_is_rotated = false, _new_is_known = true)
+	{
 		var addedItemGridIndex = undefined;
 		var isItemStacked = false;
-		
+
 		if (IsItemWhitelisted(_item))
 		{
 			var cloneItem = _item.Clone();
@@ -105,7 +134,7 @@ function Inventory(_inventoryId, _type, _size = undefined, _inventoryFilter = un
 			{
 				// CHECK ITEM LIMIT
 				var itemCount = ds_list_size(items);
-				if (++itemCount <= item_limit)
+				if (++itemCount <= item_count_limit)
 				{
 					if (!is_undefined(cloneItem.grid_index))
 					{
@@ -140,7 +169,7 @@ function Inventory(_inventoryId, _type, _size = undefined, _inventoryFilter = un
 			);
 		}
 		return addedItemGridIndex;
-    }
+	}
 	
 	static AddMultipleItems = function(_itemArray)
 	{
@@ -197,7 +226,7 @@ function Inventory(_inventoryId, _type, _size = undefined, _inventoryFilter = un
 	}
 	
 	static ReplaceWithRollback = function(_oldItem, _newItem)
-    {
+	{
 		_oldItem.sourceInventory.RemoveItemByGridIndex(_oldItem.grid_index);
 		var replacedItemGridIndex = _oldItem.sourceInventory.AddItem(_newItem);
 		if (is_undefined(replacedItemGridIndex))
@@ -207,7 +236,7 @@ function Inventory(_inventoryId, _type, _size = undefined, _inventoryFilter = un
 		}
 		
 		return replacedItemGridIndex;
-    }
+	}
 	
 	static SwapWithRollback = function(_sourceItem, _targetItem)
 	{
@@ -229,12 +258,12 @@ function Inventory(_inventoryId, _type, _size = undefined, _inventoryFilter = un
 	}
 	
 	static GetItemByIndex = function(_index)
-    {
+	{
 		return items[| _index];
-    }
+	}
 	
 	static GetItemsByIndexRange = function(_startIndex, _endIndex)
-    {
+	{
 		var itemsByRange = ds_list_create();
 		var validEndIndex = min(GetItemCount(), _endIndex);
 		for (var i = _startIndex; i < validEndIndex; i++)
@@ -246,10 +275,10 @@ function Inventory(_inventoryId, _type, _size = undefined, _inventoryFilter = un
 			}
 		}
 		return itemsByRange;
-    }
+	}
 	
 	static GetItemByGridIndex = function(_gridIndex)
-    {
+	{
 		var foundItem = undefined;
 		var itemCount = GetItemCount();
 		
@@ -264,7 +293,7 @@ function Inventory(_inventoryId, _type, _size = undefined, _inventoryFilter = un
 			}
 		}
 		return foundItem;
-    }
+	}
 	
 	static RotateItemByGridIndex = function(_gridIndex, _isRotated)
 	{
@@ -290,7 +319,7 @@ function Inventory(_inventoryId, _type, _size = undefined, _inventoryFilter = un
 						} else {
 							// Reverse rotation if item doesn't fit
 							if (item.is_rotated != originalRotation) {
-							    item.Rotate();
+							item.Rotate();
 							}
 						}
 			
@@ -304,7 +333,7 @@ function Inventory(_inventoryId, _type, _size = undefined, _inventoryFilter = un
 	}
 	
 	static RemoveItemByIndex = function(_index)
-    {
+	{
 		var isItemRemoved = false;
 		var item = GetItemByIndex(_index);
 		if (!is_undefined(item))
@@ -314,10 +343,10 @@ function Inventory(_inventoryId, _type, _size = undefined, _inventoryFilter = un
 			isItemRemoved = true;
 		}
 		return isItemRemoved;
-    }
+	}
 	
 	static RemoveItemByGridIndex = function(_gridIndex)
-    {
+	{
 		var isItemRemoved = false;
 		var itemCount = GetItemCount();
 		for (var i = 0; i < itemCount; i++)
@@ -331,7 +360,7 @@ function Inventory(_inventoryId, _type, _size = undefined, _inventoryFilter = un
 			}
 		}
 		return isItemRemoved;
-    }
+	}
 	
 	static FindEmptyIndex = function(_item)
 	{

--- a/world-against-us/scripts/item/Item.gml
+++ b/world-against-us/scripts/item/Item.gml
@@ -34,13 +34,13 @@ function Item(_name, _short_name, _icon, _size, _category, _type, _weight, _max_
 	
 	static Clone = function(_newQuantity = undefined, _sourceInventory = undefined, _gridIndex = undefined)
 	{
-		var parsedMetadata = ParseJSONStructToItemMetadata(metadata, self);
-		var cloneSize = !is_undefined(size) ? size.Clone() : undefined;
+		var cloneMetadata = (!is_undefined(metadata)) ? metadata.Clone() : undefined;
+		var cloneSize = (!is_undefined(size)) ? size.Clone() : undefined;
 		var cloneItem = new Item(
 			name, short_name, icon, cloneSize, category, type,
 			weight, max_stack, base_price, description,
 			_newQuantity ?? quantity,
-			parsedMetadata,
+			cloneMetadata,
 			is_rotated, is_known,
 			_gridIndex
 		);


### PR DESCRIPTION
Additions

- InventorySize JSON struct parse script
- InventoryFilter JSON struct parse script

Improvements

- Expanded several MetadataItem-related structs with missing Clone and OnDestroy methods

Fixes

- Default return value on Item metadata JSON struct parsing
- Backpack item JSON struct parsing
- Limited set quantity to the item's max stack value on the item database query

Tweaks

- Updated project files
- Prettier some code parts

Obsolete

- Fixed obsolete logic in the Inventory-related JSON struct parsing